### PR TITLE
refactor: align v2 phase 1 around shared framework context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 node_modules/
 dist/
+.anastacio/
+github-recovery-codes.txt
+examples/*/dist/
+examples/*/node_modules/
+examples/*/.anastacio/

--- a/README.md
+++ b/README.md
@@ -1,142 +1,125 @@
-
-
->[!IMPORTANT] Version BETA Actualmente en Desarollo
-> La version BETA esta en pruebas y pronto se pasara a RC
-
 # Anastacio
-[![npm version](https://img.shields.io/npm/v/anastacio-beta.svg)](https://www.npmjs.com/package/anastacio-beta
-)
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/SergioAnastacio/anastacio/main.yml)
 
-Anastacio es un framework para la creación de aplicaciones en React + Typescript  y APIS con Express.js + Typescript.
+Anastacio es un framework React + TypeScript orientado a agentes, enfocado
+en arquitectura explicita, inspeccion nativa y evolucion segura del codigo.
 
+La apuesta de v2 no es competir por ser el framework mas completo. La apuesta
+es construir un framework que pueda explicar la estructura del proyecto como
+dato, de forma util para humanos y para tooling automatizado.
 
-## Estructura del Proyecto
-La estructura del proyecto sigue el patrón de arquitectura limpia y se divide en las siguientes capas:
-```
-anastacio/ 
-├── src/ 
-│   ├── application/ 
-│   ├── use-cases/ 
-│   │   └── CreateServer.ts 
-│   ├── bin/ 
-│   │   └── cli.ts 
-│   ├── cli/ 
-│   │   ├── build.ts 
-│   │   ├── dev.ts
-│   │   ├── dev.ts
-│   │   ├── dev.ts 
-│   │   └── start.ts 
-│   ├── domain/ 
-│   │   ├── entities/ 
-│   │   │   └── Server.ts 
-│   │   ├── interfaces/ 
-│   │   │   └── IServerRepository.ts 
-│   │   └── services/ 
-│   │       └── ServerService.ts 
-│   ├── infrastructure/ 
-│   │   └── repositories/ 
-│   │       └── ServerRepository.ts 
-│   ├── presentation/ 
-│   │   └── controllers/ 
-│   │       └── ServerController.ts 
-│   └── server.ts 
-├── package.json 
-├── README.md 
-├── tsconfig-paths.json 
-└── tsconfig.json
+## Estado del repositorio
 
-```
-- **Dominio**: Contiene las reglas de negocio y lógica de la aplicación.
-- **Infraestructura**: Incluye la configuración de la base de datos, servidores y otros servicios externos.
-- **Aplicación**: Maneja la lógica de la aplicación, casos de uso y servicios.
-- **Presentación**: Gestiona la interfaz de usuario y la interacción con el cliente.
+Este repositorio esta en transicion hacia **Anastacio v2**.
 
+La linea de trabajo de v2 vive en la rama `dev`. El objetivo actual no es
+cerrar todas las capacidades de un meta-framework moderno, sino consolidar un
+MVP enfocado y ejecutable.
 
-## Instalación
+## Direccion de v2
 
-Para instalar el framework usa el siguiente comando de NPX:
+Anastacio v2 se apoya en estas ideas:
+
+- `explicit over magic`
+- routing por archivos
+- manifests estructurados
+- diagnosticos utiles
+- comandos semanticos
+- evolucion segura del proyecto
+
+La idea central es simple:
+
+> Anastacio v2 debe ganar por claridad estructural, no por cantidad de
+> features.
+
+## Foco actual del MVP
+
+La primera etapa de v2 esta enfocada en:
+
+- `anastacio dev`
+- `anastacio build`
+- config loader basico
+- routing por archivos
+- layouts basicos
+- `routes.manifest.json`
+- `project-context.md`
+- `anastacio inspect`
+- `anastacio inspect --json`
+- `anastacio doctor` minimo
+
+Capacidades como server actions, generadores avanzados, graph profundo y SSR
+quedan para fases posteriores.
+
+## Documentos base
+
+La direccion actual de producto y arquitectura esta documentada aqui:
+
+- [Vision y arquitectura v2](./anastacio_v2_vision_y_arquitectura.md)
+- [MVP endurecido](./anastacio_v2_mvp_endurecido.md)
+- [Backlog Fase 1](./anastacio_v2_fase1_tareas.md)
+
+## Roadmap resumido
+
+### Fase 1
+
+Core utilizable e inspeccion minima:
+
+- CLI minima
+- build y dev server
+- router por archivos
+- `routes.manifest.json`
+- `inspect --json`
+
+### Fase 2
+
+Introspeccion util:
+
+- `project-context.md`
+- `diagnostics.json`
+- `doctor`
+- grafo simple de dependencias
+
+### Fase 3
+
+Automatizacion segura:
+
+- `explain <target>`
+- generadores iniciales
+- contratos de acciones
+
+## Comandos actuales del repositorio
+
+Mientras el core de v2 madura, estos scripts siguen disponibles:
 
 ```bash
-    npx create-anastacio-app myapp
+npm run build
+npm run lint
+npm run format
 ```
 
-## Uso
+## Contribucion
 
->[!NOTE] Uso de el comando Node  en la Version 22.10.0
-> Puedes usar el comando 
-> ```bash
->   node --run script
-> ```
-Para instalar las dependencias del proyecto, ejecute el siguiente comando:
+Si vas a trabajar sobre v2:
 
-### Start
-Para iniciar el servidor, utilice el siguiente comando:
+1. parte desde una rama de feature basada en la linea v2 activa;
+2. alinea cambios con la arquitectura v2 y el backlog de Fase 1;
+3. evita introducir features fuera del foco del MVP sin cerrar antes los
+   contratos base.
 
-```bash
-    node --run start
-```
-### Dev
-Para iniciar el servidor, de desarollo utilice el siguiente comando:
+## Arquitectura oficial v2
 
-```bash
-    node --run dev
-```
-### Build
+A partir de esta migracion, los modulos oficiales de Anastacio v2 son:
 
-Para compilar el proyecto, utiliza el siguiente comando:
-### Test
-Para ejecutar las pruebas, utiliza el siguiente comando:
-### Test coverage
-Para generar un informe de cobertura de pruebas, utiliza el siguiente comando:
-### Test E2E
-Para ejecutar pruebas end-to-end, utiliza el siguiente comando:
-### Lint
-Para analizar el código en busca de errores y problemas de estilo, utiliza el siguiente comando:
-### Formatt
-Para formatear el código, utiliza el siguiente comando:
+- `src/core`
+- `src/router`
+- `src/inspector`
+- `src/doctor`
+- `src/shared`
 
-## Contribución
-
-Si desea contribuir a este proyecto, por favor siga los siguientes pasos:
-
-1. Haga un fork del repositorio.
-2. Cree una nueva rama (`git checkout -b feature/nueva-funcionalidad`).
-3. Realice los cambios necesarios y haga commit (`git commit -m 'Añadir nueva funcionalidad'`).
-4. Empuje los cambios a la rama (`git push origin feature/nueva-funcionalidad`).
-5. Cree un Pull Request.
+Las carpetas heredadas (`src/adapters`, `src/applications`, `src/dominio` y
+partes antiguas de `src/infrastructure`) deben considerarse transicionales.
+No deben recibir nuevas capacidades estructurales mientras la migracion a v2
+este en curso.
 
 ## Licencia
 
-Este proyecto está licenciado bajo la Licencia MIT. Consulte el archivo `LICENSE` para obtener más detalles.
-
-## Características
-
-- **Modularidad**: Estructura modular que facilita la escalabilidad y el mantenimiento.
-- **TypeScript**: Escrito en TypeScript para aprovechar sus características de tipado estático.
-- **Arquitectura Limpia**: Sigue el patrón de arquitectura limpia para una separación clara de responsabilidades.
-- **Facilidad de Uso**: Comandos simples para iniciar, desarrollar y construir el proyecto.
-
-## Requisitos
->[!WARNING] Error con Node 23.0
->  Existe un error con Node 23.0  que no permite usar el comando npx Recomendamos usar la version 22.10.0
-- Node.js >= v22.10.0 
-- npm >= 10.9.0
-
-## Documentación
-
-> [!CAUTION] Documentacion incompleta
-> Documentacion en Camino ... cuando se termine de desarollar el core.
-
-Para más detalles sobre cómo utilizar Anastacio, por favor consulte la [documentación oficial](https://example.com/docs).
-
-## Roadmap
-
-- [ ] Completar la documentación
-- [ ] Añadir más pruebas unitarias
-- [ ] Mejorar la cobertura de pruebas E2E
-- [ ] Implementar nuevas características solicitadas por la comunidad
-
-## Agradecimientos
-
-Agradecemos a todos los contribuyentes y a la comunidad por su apoyo y colaboración en el desarrollo de Anastacio.
+MIT

--- a/anastacio_v2_fase1_tareas.md
+++ b/anastacio_v2_fase1_tareas.md
@@ -1,0 +1,142 @@
+# Anastacio v2 - Fase 1 a tareas
+
+## Objetivo de Fase 1
+
+Construir un core utilizable que permita:
+
+- correr una app con `anastacio dev`;
+- compilar con `anastacio build`;
+- resolver rutas por archivos;
+- generar `routes.manifest.json`;
+- exponer `inspect --json`.
+
+## Resultado esperado
+
+Al cierre de Fase 1, un proyecto minimo debe poder arrancar, compilarse e
+informar su estructura de rutas sin ambiguedad.
+
+## Backlog tecnico
+
+### 1. Definir el modelo base del framework
+
+- Crear tipos base para config, rutas, manifests y diagnosticos minimos.
+- Definir la interfaz de plugin y el contexto compartido del framework.
+- Separar los contratos serializables en un modulo `shared`.
+
+Entregable:
+- tipos y contratos base en codigo;
+- estructura interna clara para `core`, `router` e `inspector`.
+
+### 2. Introducir un config loader minimo
+
+- Definir `anastacio.config.ts` como entrada oficial.
+- Implementar carga con defaults claros.
+- Validar errores de configuracion con mensajes accionables.
+
+Entregable:
+- loader funcional;
+- contrato tipado de configuracion;
+- fallback cuando no exista config.
+
+### 3. Endurecer la CLI minima
+
+- Consolidar `dev`, `build` e `inspect` como comandos oficiales.
+- Separar parsing de argumentos de la logica de ejecucion.
+- Asegurar salidas legibles para humano y JSON cuando aplique.
+
+Entregable:
+- CLI consistente;
+- contrato minimo para opciones;
+- punto de entrada estable para nuevas capacidades.
+
+### 4. Reorganizar el pipeline de compilacion
+
+- Separar responsabilidades de `compiler` y `dev server`.
+- Eliminar supuestos duros del repo que hoy mezclan framework con app.
+- Hacer que el build consuma config y puntos de entrada definidos.
+
+Entregable:
+- pipeline de build con fronteras mas limpias;
+- menor acoplamiento entre runtime y estructura del repo.
+
+### 5. Formalizar el router por archivos
+
+- Definir reglas para `page`, `layout`, rutas dinamicas y rutas index.
+- Reemplazar heuristicas fragiles por un modelo `RouteDefinition`.
+- Generar rutas desde disco de forma deterministica.
+
+Entregable:
+- router estable;
+- contrato de ruta;
+- casos base soportados.
+
+### 6. Generar `routes.manifest.json`
+
+- Serializar rutas resueltas al directorio `.anastacio/`.
+- Incluir path, archivo fuente, layout y parametros dinamicos.
+- Asegurar que el manifest sea estable entre ejecuciones.
+
+Entregable:
+- manifest util y versionable;
+- base para `inspect`.
+
+### 7. Implementar `inspect`
+
+- Leer el modelo de rutas y exponer salida para humano.
+- Agregar `--json` con formato estable.
+- Dejar preparado el camino para futuros manifests.
+
+Entregable:
+- `anastacio inspect`
+- `anastacio inspect --json`
+
+### 8. Preparar `project-context.md` minimo
+
+- Generar un resumen de estructura del proyecto.
+- Incluir rutas detectadas, convenciones activas y observaciones basicas.
+- Mantener el formato simple y legible.
+
+Entregable:
+- primer artefacto narrativo generado por el framework.
+
+### 9. Introducir diagnosticos minimos
+
+- Detectar archivos requeridos faltantes.
+- Detectar rutas invalidas o colisiones simples.
+- Emitir una estructura base para futuros reportes.
+
+Entregable:
+- base de `diagnostics.json`;
+- insumos para un `doctor` simple en Fase 2.
+
+### 10. Crear fixture o app de ejemplo
+
+- Separar claramente framework y app de prueba.
+- Mover ejemplos a `examples/` o `fixtures/`.
+- Validar el flujo real de `dev`, `build` e `inspect` sobre esa app.
+
+Entregable:
+- ejemplo minimo reproducible;
+- menor confusion entre codigo del framework y codigo de app.
+
+## Orden recomendado de ejecucion
+
+1. modelo base del framework
+2. config loader
+3. CLI minima
+4. pipeline de build
+5. router por archivos
+6. `routes.manifest.json`
+7. `inspect --json`
+8. `project-context.md`
+9. diagnosticos minimos
+10. fixture de ejemplo y validacion
+
+## Criterios de cierre de Fase 1
+
+- existe una configuracion minima estable;
+- `dev` y `build` funcionan sobre una app de ejemplo;
+- el router genera una salida deterministica;
+- `routes.manifest.json` se escribe en `.anastacio/`;
+- `inspect --json` expone informacion util y estable;
+- el repo ya no mezcla tanto codigo del framework con supuestos de una app.

--- a/examples/basic-app/anastacio.config.ts
+++ b/examples/basic-app/anastacio.config.ts
@@ -1,0 +1,8 @@
+export default {
+	paths: {
+		srcDir: "src",
+		appDir: "src/app",
+		entryFile: "src/index.tsx",
+		outDir: "dist",
+	},
+};

--- a/examples/basic-app/package-lock.json
+++ b/examples/basic-app/package-lock.json
@@ -1,0 +1,101 @@
+{
+  "name": "anastacio-basic-app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "anastacio-basic-app",
+      "dependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-router-dom": "^7.0.0"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
+      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
+      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/examples/basic-app/package.json
+++ b/examples/basic-app/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "anastacio-basic-app",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.0.0"
+  }
+}

--- a/examples/basic-app/src/AppRouter.tsx
+++ b/examples/basic-app/src/AppRouter.tsx
@@ -1,0 +1,50 @@
+
+import React, { Suspense, lazy } from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <ApperrorPage />;
+    }
+
+    return this.props.children;
+  }
+}
+
+const Apploading = lazy(() => import('./app/loading'));
+const Appnotfound = lazy(() => import('./app/notfound'));
+const ApperrorPage = () => null;
+const RoutePageAppAdminUsersPage = lazy(() => import('./app/admin/users/page'));
+const RoutePageAppCustomersIdPage = lazy(() => import('./app/customers/[id]/page'));
+const RoutePageAppPage = lazy(() => import('./app/page'));
+const RouteLayoutAppLayout = lazy(() => import('./app/layout'));
+
+const AppRouter = () => (
+  <Router>
+    <ErrorBoundary>
+      <Suspense fallback={<Apploading />}>
+        <Routes>
+
+      <Route element={<RouteLayoutAppLayout />}>
+        <Route path="/" element={<RoutePageAppPage />} />
+        <Route path="/admin/users" element={<RoutePageAppAdminUsersPage />} />
+        <Route path="/customers/:id" element={<RoutePageAppCustomersIdPage />} />
+      </Route>
+          <Route path="*" element={<Appnotfound />} />
+        </Routes>
+      </Suspense>
+    </ErrorBoundary>
+  </Router>
+);
+
+export default AppRouter;

--- a/examples/basic-app/src/app/admin/users/page.tsx
+++ b/examples/basic-app/src/app/admin/users/page.tsx
@@ -1,0 +1,8 @@
+export default function AdminUsersPage() {
+	return (
+		<section>
+			<h2>Admin Users</h2>
+			<p>Nested route fixture for file-based routing.</p>
+		</section>
+	);
+}

--- a/examples/basic-app/src/app/customers/[id]/page.tsx
+++ b/examples/basic-app/src/app/customers/[id]/page.tsx
@@ -1,0 +1,12 @@
+import { useParams } from "react-router-dom";
+
+export default function CustomerDetailPage() {
+	const params = useParams<{ id: string }>();
+
+	return (
+		<section>
+			<h2>Customer Detail</h2>
+			<p>Customer id: {params.id ?? "unknown"}</p>
+		</section>
+	);
+}

--- a/examples/basic-app/src/app/layout.tsx
+++ b/examples/basic-app/src/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+import { Outlet } from "react-router-dom";
+
+interface RootLayoutProps {
+	children?: ReactNode;
+}
+
+export default function RootLayout({
+	children,
+}: RootLayoutProps) {
+	return (
+		<main style={{ fontFamily: "sans-serif", padding: "2rem" }}>
+			<header style={{ marginBottom: "1rem" }}>
+				<h1>Anastacio Basic App</h1>
+				<p>Example fixture for Phase 1 routing and inspect.</p>
+			</header>
+			{children ?? <Outlet />}
+		</main>
+	);
+}

--- a/examples/basic-app/src/app/loading.tsx
+++ b/examples/basic-app/src/app/loading.tsx
@@ -1,0 +1,3 @@
+export default function LoadingPage() {
+	return <p>Loading basic app...</p>;
+}

--- a/examples/basic-app/src/app/notfound.tsx
+++ b/examples/basic-app/src/app/notfound.tsx
@@ -1,0 +1,3 @@
+export default function NotFoundPage() {
+	return <p>Route not found.</p>;
+}

--- a/examples/basic-app/src/app/page.tsx
+++ b/examples/basic-app/src/app/page.tsx
@@ -1,0 +1,8 @@
+export default function HomePage() {
+	return (
+		<section>
+			<h2>Home</h2>
+			<p>This is the root page for the Anastacio basic app fixture.</p>
+		</section>
+	);
+}

--- a/examples/basic-app/src/index.tsx
+++ b/examples/basic-app/src/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import AppRouter from "./AppRouter";
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+	throw new Error("Root element #root was not found.");
+}
+
+ReactDOM.createRoot(rootElement).render(
+	<React.StrictMode>
+		<AppRouter />
+	</React.StrictMode>,
+);

--- a/examples/basic-app/tsconfig.json
+++ b/examples/basic-app/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*",
+    "anastacio.config.ts"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,11 @@
         "oxlint": "^1.48.0",
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.9.3"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0",
+        "react-router-dom": "^6.28.0 || ^7.0.0"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -1700,6 +1705,19 @@
         "node": ">=20"
       }
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/css-declaration-sorter": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.1.tgz",
@@ -2618,6 +2636,68 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
+      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
+      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "react-router": "7.13.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/sax": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
@@ -2626,6 +2706,12 @@
       "engines": {
         "node": ">=11.0.0"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -2638,6 +2724,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.5",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
   "keywords": [],
   "author": "Sergio Anastacio",
   "license": "MIT",
+  "peerDependencies": {
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0",
+    "react-router-dom": "^6.28.0 || ^7.0.0"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.2",
     "@types/express": "^5.0.6",

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -3,6 +3,8 @@ import { Command } from "commander";
 import { startApp } from "../cli/start.js";
 import { buildApp } from "../cli/build.js";
 import { devApp } from "../cli/dev.js";
+import { inspectApp } from "../cli/inspect.js";
+import { doctorApp } from "../cli/doctor.js";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
@@ -16,6 +18,16 @@ const packageJson = JSON.parse(
 	readFileSync(join(__dirname, "../../package.json"), "utf8"),
 );
 
+function parsePort(value: string): number {
+	const parsedPort = Number.parseInt(value, 10);
+
+	if (Number.isNaN(parsedPort)) {
+		throw new Error(`Invalid port value: ${value}`);
+	}
+
+	return parsedPort;
+}
+
 program
 	.name("anastacio")
 	.description("CLI for the Anastacio framework")
@@ -24,25 +36,46 @@ program
 program
 	.command("start")
 	.description("Start the application in production mode")
-	.option("-p, --port <port>", "Specify a port number", "3000")
-	.action((options) => {
-		startApp(options);
+	.option("-p, --port <port>", "Specify a port number", parsePort)
+	.option("-r, --root <path>", "Project root directory", ".")
+	.action(async (options) => {
+		await startApp(options);
 	});
 
 program
 	.command("build")
 	.description("Build the application for production")
 	.option("-m, --mode <mode>", "Specify the build mode", "production")
-	.action((options) => {
-		buildApp(options);
+	.option("-r, --root <path>", "Project root directory", ".")
+	.action(async (options) => {
+		await buildApp(options);
 	});
 
 program
 	.command("dev")
 	.description("Start the application in development mode")
-	.option("-p, --port <port>", "Specify a port number", "3000")
-	.action((options) => {
-		devApp(options);
+	.option("-p, --port <port>", "Specify a port number", parsePort)
+	.option("-r, --root <path>", "Project root directory", ".")
+	.action(async (options) => {
+		await devApp(options);
 	});
 
-program.parse(process.argv);
+program
+	.command("inspect")
+	.description("Inspect the project structure and emit manifests")
+	.option("-r, --root <path>", "Project root directory", ".")
+	.option("--json", "Emit machine-readable JSON output", false)
+	.action(async (options) => {
+		await inspectApp(options);
+	});
+
+program
+	.command("doctor")
+	.description("Run structural diagnostics and emit diagnostics.json")
+	.option("-r, --root <path>", "Project root directory", ".")
+	.option("--json", "Emit machine-readable JSON output", false)
+	.action(async (options) => {
+		await doctorApp(options);
+	});
+
+await program.parseAsync(process.argv);

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -1,23 +1,22 @@
 import { formatTime, Timer } from "../utils/Timer.js";
 import { EsbuildCompiler } from "../infrastructure/compiler/EsbuildCompiler.js";
 import { ServerMode } from "../infrastructure/webserver/ServerMode.js";
-import { join } from "node:path";
+import { createFrameworkContext } from "../core/index.js";
 
 interface BuildAppOptions {
 	mode: string;
+	root?: string;
 }
 export async function buildApp(options: BuildAppOptions): Promise<void> {
-	//Get dist folder on the root of the project
-	const distDir = join(process.cwd(), "dist");
-	//Get src folder on the root of the project
-	const srcDir = join(process.cwd(), "src/index.tsx");
+	const framework = await createFrameworkContext(options.root ?? process.cwd());
+	const { config } = framework;
 	//Define the servermode
 	const serverMode =
 		options.mode === "production"
 			? ServerMode.Production
 			: ServerMode.Development;
 	// Initialize the compiler
-	const compiler = new EsbuildCompiler([srcDir], distDir, serverMode);
+	const compiler = new EsbuildCompiler(config, serverMode);
 	// Build the application
 	await Timer(`${options.mode} Build`, async () => {
 		console.log(`[${formatTime()}]`, "Building the application...");

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -1,19 +1,19 @@
 import { HttpServer } from "../infrastructure/webserver/HttpServer.js";
 import { ServerMode } from "../infrastructure/webserver/ServerMode.js";
+import { createFrameworkContext } from "../core/index.js";
 
 interface DevAppOptions {
-	port: number;
+	port?: number;
+	root?: string;
 }
 
 export async function devApp(options: DevAppOptions): Promise<void> {
-	//Instanciar un servidor en modo desarollo
-	//Configuracion
-	const hostname = "127.0.0.1"; // o localhost
-	const port = options.port;
-	const wsPort = 3001;
+	const framework = await createFrameworkContext(options.root ?? process.cwd());
+	const { config } = framework;
 	const mode = ServerMode.Development;
-	//Instanciar el server
-	const server = new HttpServer(hostname, port, wsPort, mode);
+	const server = new HttpServer(config, mode, {
+		port: options.port,
+	});
 	server.start(); //Llamamos su metodo start
 
 	//Procesar las señales de terminacion

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,0 +1,17 @@
+import { diagnoseProject, formatDoctorReport } from "../doctor/index.js";
+
+interface DoctorAppOptions {
+	root?: string;
+	json?: boolean;
+}
+
+export async function doctorApp(options: DoctorAppOptions): Promise<void> {
+	const report = await diagnoseProject(options.root ?? process.cwd());
+
+	if (options.json) {
+		console.log(JSON.stringify(report, null, 2));
+		return;
+	}
+
+	console.log(formatDoctorReport(report));
+}

--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -1,0 +1,20 @@
+import {
+	formatInspectionReport,
+	inspectProject,
+} from "../inspector/index.js";
+
+interface InspectAppOptions {
+	root?: string;
+	json?: boolean;
+}
+
+export async function inspectApp(options: InspectAppOptions): Promise<void> {
+	const report = await inspectProject(options.root ?? process.cwd());
+
+	if (options.json) {
+		console.log(JSON.stringify(report, null, 2));
+		return;
+	}
+
+	console.log(formatInspectionReport(report));
+}

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -1,17 +1,18 @@
 import { HttpServer } from "../infrastructure/webserver/HttpServer.js";
 import { ServerMode } from "../infrastructure/webserver/ServerMode.js";
+import { createFrameworkContext } from "../core/index.js";
 
 interface startAppOptions {
-	port: number;
+	port?: number;
+	root?: string;
 }
 export async function startApp(options: startAppOptions): Promise<void> {
-	//Configuracion del server
-	const hostname = "127.0.0.1"; // o localhost
-	const port = options.port;
-	const wsPort = 3001;
+	const framework = await createFrameworkContext(options.root ?? process.cwd());
+	const { config } = framework;
 	const mode = ServerMode.Production;
-	// Instanciar el server
-	const server = new HttpServer(hostname, port, wsPort, mode);
+	const server = new HttpServer(config, mode, {
+		port: options.port,
+	});
 	server.start(); //Llamamos su metodo start
 	//Procesar las señales de terminacion
 	process.on("SIGINT", () => server.handleSessionStop("SIGINT"));

--- a/src/core/config/index.ts
+++ b/src/core/config/index.ts
@@ -1,0 +1,4 @@
+export {
+	findAnastacioConfigPath,
+	loadAnastacioConfig,
+} from "./loadAnastacioConfig.js";

--- a/src/core/config/loadAnastacioConfig.ts
+++ b/src/core/config/loadAnastacioConfig.ts
@@ -1,0 +1,170 @@
+import { build } from "esbuild";
+import { existsSync, readFileSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
+import type {
+	AnastacioConfig,
+	AnastacioUserConfig,
+	AnastacioUserPathsConfig,
+} from "../../shared/contracts/index.js";
+
+const CONFIG_FILE_NAMES = [
+	"anastacio.config.ts",
+	"anastacio.config.js",
+	"anastacio.config.mjs",
+	"anastacio.config.json",
+];
+
+export async function loadAnastacioConfig(
+	projectRoot = process.cwd(),
+): Promise<AnastacioConfig> {
+	const rootDir = resolve(projectRoot);
+	const configPath = findAnastacioConfigPath(rootDir);
+	const userConfig = configPath
+		? await loadUserConfigFile(configPath)
+		: ({} satisfies AnastacioUserConfig);
+
+	return resolveAnastacioConfig(rootDir, userConfig);
+}
+
+export function findAnastacioConfigPath(projectRoot: string): string | null {
+	for (const fileName of CONFIG_FILE_NAMES) {
+		const candidate = join(projectRoot, fileName);
+		if (existsSync(candidate)) {
+			return candidate;
+		}
+	}
+
+	return null;
+}
+
+async function loadUserConfigFile(
+	configPath: string,
+): Promise<AnastacioUserConfig> {
+	if (configPath.endsWith(".json")) {
+		return parseUserConfig(JSON.parse(readFileSync(configPath, "utf8")));
+	}
+
+	const result = await build({
+		entryPoints: [configPath],
+		bundle: true,
+		format: "esm",
+		platform: "node",
+		write: false,
+		logLevel: "silent",
+		target: ["node22"],
+	});
+
+	const bundledCode = result.outputFiles[0]?.text;
+	if (!bundledCode) {
+		return {};
+	}
+
+	const moduleUrl = `data:text/javascript;base64,${Buffer.from(
+		bundledCode,
+		"utf8",
+	).toString("base64")}`;
+	const loadedModule = await import(moduleUrl);
+
+	return parseUserConfig(loadedModule.default ?? loadedModule.config ?? {});
+}
+
+function parseUserConfig(value: unknown): AnastacioUserConfig {
+	if (!isRecord(value)) {
+		return {};
+	}
+
+	const paths = isRecord(value.paths)
+		? parseUserPathsConfig(value.paths)
+		: undefined;
+	const dev = isRecord(value.dev) ? parseDevConfig(value.dev) : undefined;
+
+	return {
+		...(paths ? { paths } : {}),
+		...(dev ? { dev } : {}),
+	};
+}
+
+function parseUserPathsConfig(
+	value: Record<string, unknown>,
+): AnastacioUserPathsConfig {
+	return {
+		...(typeof value.srcDir === "string" ? { srcDir: value.srcDir } : {}),
+		...(typeof value.appDir === "string" ? { appDir: value.appDir } : {}),
+		...(typeof value.publicDir === "string"
+			? { publicDir: value.publicDir }
+			: {}),
+		...(typeof value.outDir === "string" ? { outDir: value.outDir } : {}),
+		...(typeof value.entryFile === "string"
+			? { entryFile: value.entryFile }
+			: {}),
+		...(typeof value.internalDir === "string"
+			? { internalDir: value.internalDir }
+			: {}),
+		...(typeof value.bundleFile === "string"
+			? { bundleFile: value.bundleFile }
+			: {}),
+	};
+}
+
+function parseDevConfig(
+	value: Record<string, unknown>,
+): AnastacioUserConfig["dev"] {
+	return {
+		...(typeof value.host === "string" ? { host: value.host } : {}),
+		...(typeof value.port === "number" ? { port: value.port } : {}),
+		...(typeof value.wsPort === "number" ? { wsPort: value.wsPort } : {}),
+	};
+}
+
+function resolveAnastacioConfig(
+	rootDir: string,
+	userConfig: AnastacioUserConfig,
+): AnastacioConfig {
+	const srcDir = resolveProjectPath(rootDir, userConfig.paths?.srcDir ?? "src");
+	const outDir = resolveProjectPath(rootDir, userConfig.paths?.outDir ?? "dist");
+	const appDir = resolveProjectPath(
+		rootDir,
+		userConfig.paths?.appDir ?? join(srcDir, "app"),
+	);
+	const entryFile = resolveProjectPath(
+		rootDir,
+		userConfig.paths?.entryFile ?? join(srcDir, "index.tsx"),
+	);
+
+	return {
+		rootDir,
+		paths: {
+			srcDir,
+			appDir,
+			publicDir: resolveProjectPath(
+				rootDir,
+				userConfig.paths?.publicDir ?? "public",
+			),
+			outDir,
+			entryFile,
+			internalDir: resolveProjectPath(
+				rootDir,
+				userConfig.paths?.internalDir ?? ".anastacio",
+			),
+			bundleFile: resolveProjectPath(
+				rootDir,
+				userConfig.paths?.bundleFile ?? join(outDir, "bundler.js"),
+			),
+		},
+		dev: {
+			host: userConfig.dev?.host ?? "127.0.0.1",
+			port: userConfig.dev?.port ?? 3000,
+			wsPort: userConfig.dev?.wsPort ?? 3001,
+		},
+	};
+}
+
+function resolveProjectPath(projectRoot: string, targetPath: string): string {
+	return isAbsolute(targetPath)
+		? targetPath
+		: resolve(projectRoot, targetPath);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -1,0 +1,22 @@
+import { loadAnastacioConfig } from "./config/index.js";
+import { resolveRoutes } from "../router/index.js";
+import type { AnastacioConfig, RouteDefinition } from "../shared/contracts/index.js";
+
+export interface AnastacioFrameworkContext {
+	rootDir: string;
+	config: AnastacioConfig;
+	routes: RouteDefinition[];
+}
+
+export async function createFrameworkContext(
+	projectRoot = process.cwd(),
+): Promise<AnastacioFrameworkContext> {
+	const config = await loadAnastacioConfig(projectRoot);
+	const routes = resolveRoutes(config);
+
+	return {
+		rootDir: config.rootDir,
+		config,
+		routes,
+	};
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,6 @@
+export type { AnastacioFrameworkContext } from "./context.js";
+export { createFrameworkContext } from "./context.js";
+export {
+	findAnastacioConfigPath,
+	loadAnastacioConfig,
+} from "./config/index.js";

--- a/src/doctor/diagnoseProject.ts
+++ b/src/doctor/diagnoseProject.ts
@@ -1,0 +1,280 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import { createFrameworkContext, findAnastacioConfigPath } from "../core/index.js";
+import { writeRoutesManifest } from "../router/index.js";
+import type {
+	AnastacioConfig,
+	Diagnostic,
+	DiagnosticReport,
+	RouteDefinition,
+} from "../shared/contracts/index.js";
+
+export interface DoctorReport {
+	rootDir: string;
+	paths: {
+		configFile: string | null;
+		appDir: string;
+		entryFile: string;
+		internalDir: string;
+	};
+	artifacts: {
+		diagnostics: string;
+		routesManifest: string;
+	};
+	diagnostics: Diagnostic[];
+}
+
+export async function diagnoseProject(
+	projectRoot = process.cwd(),
+): Promise<DoctorReport> {
+	const configPath = findAnastacioConfigPath(projectRoot);
+	const framework = await createFrameworkContext(projectRoot);
+	const { config, routes } = framework;
+	const diagnostics = collectDiagnostics(config, routes, configPath);
+	const routesManifestPath = writeRoutesManifest(config, routes);
+	const diagnosticsPath = writeDiagnosticsReport(config, diagnostics);
+
+	return {
+		rootDir: config.rootDir,
+		paths: {
+			configFile: configPath
+				? toProjectRelative(config.rootDir, configPath)
+				: null,
+			appDir: toProjectRelative(config.rootDir, config.paths.appDir),
+			entryFile: toProjectRelative(config.rootDir, config.paths.entryFile),
+			internalDir: toProjectRelative(config.rootDir, config.paths.internalDir),
+		},
+		artifacts: {
+			diagnostics: toProjectRelative(config.rootDir, diagnosticsPath),
+			routesManifest: toProjectRelative(config.rootDir, routesManifestPath),
+		},
+		diagnostics,
+	};
+}
+
+export function formatDoctorReport(report: DoctorReport): string {
+	const errorCount = report.diagnostics.filter(
+		(diagnostic) => diagnostic.severity === "error",
+	).length;
+	const warningCount = report.diagnostics.filter(
+		(diagnostic) => diagnostic.severity === "warning",
+	).length;
+	const infoCount = report.diagnostics.filter(
+		(diagnostic) => diagnostic.severity === "info",
+	).length;
+
+	const lines = [
+		"Anastacio Doctor",
+		`root: ${report.rootDir}`,
+		`configFile: ${report.paths.configFile ?? "(defaults)"}`,
+		`appDir: ${report.paths.appDir}`,
+		`entryFile: ${report.paths.entryFile}`,
+		`diagnostics.json: ${report.artifacts.diagnostics}`,
+		`routes.manifest.json: ${report.artifacts.routesManifest}`,
+		`errors: ${errorCount} | warnings: ${warningCount} | info: ${infoCount}`,
+	];
+
+	if (report.diagnostics.length === 0) {
+		lines.push("No issues detected.");
+		return lines.join("\n");
+	}
+
+	lines.push("");
+	for (const diagnostic of report.diagnostics) {
+		const location = diagnostic.file ? ` (${diagnostic.file})` : "";
+		const suggestion = diagnostic.suggestion
+			? ` -> ${diagnostic.suggestion}`
+			: "";
+		lines.push(
+			`${diagnostic.severity.toUpperCase()} ${diagnostic.code}${location}: ${diagnostic.message}${suggestion}`,
+		);
+	}
+
+	return lines.join("\n");
+}
+
+function collectDiagnostics(
+	config: AnastacioConfig,
+	routes: RouteDefinition[],
+	configPath: string | null,
+): Diagnostic[] {
+	const diagnostics: Diagnostic[] = [];
+	const appDir = config.paths.appDir;
+	const entryFile = config.paths.entryFile;
+
+	if (!configPath) {
+		diagnostics.push({
+			code: "CONFIG_FILE_MISSING",
+			severity: "info",
+			message:
+				"No anastacio.config.* file was found. The project is running on implicit defaults.",
+			suggestion:
+				"Add an anastacio.config.ts file to make paths and dev settings explicit.",
+		});
+	}
+
+	if (!existsSync(appDir)) {
+		diagnostics.push({
+			code: "APP_DIR_MISSING",
+			severity: "error",
+			message: "The configured app directory does not exist.",
+			file: toProjectRelative(config.rootDir, appDir),
+			suggestion:
+				"Create the directory or update paths.appDir in anastacio.config.ts.",
+		});
+	}
+
+	if (!existsSync(entryFile)) {
+		diagnostics.push({
+			code: "ENTRY_FILE_MISSING",
+			severity: "error",
+			message: "The configured entry file does not exist.",
+			file: toProjectRelative(config.rootDir, entryFile),
+			suggestion:
+				"Create the file or update paths.entryFile in anastacio.config.ts.",
+		});
+	}
+
+	if (existsSync(appDir) && !hasKnownFile(appDir, ROOT_LAYOUT_FILE_NAMES)) {
+		diagnostics.push({
+			code: "ROOT_LAYOUT_MISSING",
+			severity: "info",
+			message:
+				"No root layout file was detected under the configured app directory.",
+			file: toProjectRelative(config.rootDir, appDir),
+			suggestion:
+				"Add src/app/layout.tsx so the application shell is explicit and shared across routes.",
+		});
+	}
+
+	if (routes.length === 0 && existsSync(appDir)) {
+		diagnostics.push({
+			code: "NO_ROUTES_DETECTED",
+			severity: "warning",
+			message: "No routes were detected under the configured app directory.",
+			file: toProjectRelative(config.rootDir, appDir),
+			suggestion: "Add a page.tsx file under src/app or adjust paths.appDir.",
+		});
+	}
+
+	if (routes.length > 0 && !routes.some((route) => route.path === "/")) {
+		diagnostics.push({
+			code: "ROOT_ROUTE_MISSING",
+			severity: "warning",
+			message: "No root route (/) was detected.",
+			suggestion: "Add src/app/page.tsx or review your routing conventions.",
+		});
+	}
+
+	const routeCounts = new Map<string, number>();
+	for (const route of routes) {
+		routeCounts.set(route.path, (routeCounts.get(route.path) ?? 0) + 1);
+	}
+
+	for (const [routePath, count] of routeCounts.entries()) {
+		if (count > 1) {
+			diagnostics.push({
+				code: "DUPLICATE_ROUTE_PATH",
+				severity: "error",
+				message: `The route path "${routePath}" is declared more than once.`,
+				suggestion:
+					"Rename or reorganize the conflicting route files so each path is unique.",
+			});
+		}
+	}
+
+	const routesBySignature = new Map<string, RouteDefinition[]>();
+	for (const route of routes) {
+		const signature = toRouteSignature(route.path);
+		const entries = routesBySignature.get(signature) ?? [];
+		entries.push(route);
+		routesBySignature.set(signature, entries);
+	}
+
+	for (const [signature, signatureRoutes] of routesBySignature.entries()) {
+		const distinctPaths = new Set(
+			signatureRoutes.map((route) => route.path),
+		);
+		if (distinctPaths.size < 2) {
+			continue;
+		}
+
+		const declaredFiles = signatureRoutes
+			.map((route) => route.file)
+			.sort((left, right) => left.localeCompare(right))
+			.join(", ");
+
+		diagnostics.push({
+			code: "DUPLICATE_ROUTE_SIGNATURE",
+			severity: "error",
+			message: `Multiple route files collapse to the same route signature "${signature}": ${declaredFiles}.`,
+			suggestion:
+				"Rename or reorganize dynamic segments so each semantic route shape is unique.",
+		});
+	}
+
+	return diagnostics.sort(
+		(left, right) =>
+			severityRank(left.severity) - severityRank(right.severity) ||
+			left.code.localeCompare(right.code),
+	);
+}
+
+function writeDiagnosticsReport(
+	config: AnastacioConfig,
+	diagnostics: Diagnostic[],
+): string {
+	mkdirSync(config.paths.internalDir, { recursive: true });
+
+	const outputPath = join(config.paths.internalDir, "diagnostics.json");
+	const report: DiagnosticReport = {
+		kind: "diagnostic-report",
+		version: 1,
+		diagnostics,
+	};
+
+	writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+	return outputPath;
+}
+
+function severityRank(severity: Diagnostic["severity"]): number {
+	switch (severity) {
+		case "error":
+			return 0;
+		case "warning":
+			return 1;
+		default:
+			return 2;
+	}
+}
+
+const ROOT_LAYOUT_FILE_NAMES = ["layout.tsx", "layout.jsx"];
+
+function hasKnownFile(directory: string, fileNames: string[]): boolean {
+	for (const fileName of fileNames) {
+		if (existsSync(join(directory, fileName))) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function toRouteSignature(routePath: string): string {
+	if (routePath === "/") {
+		return routePath;
+	}
+
+	const segments = routePath.split("/").filter(Boolean);
+	return `/${segments
+		.map((segment) => (segment.startsWith(":") ? ":*" : segment))
+		.join("/")}`;
+}
+
+function toProjectRelative(projectRoot: string, filePath: string): string {
+	return normalizePath(relative(projectRoot, filePath));
+}
+
+function normalizePath(value: string): string {
+	return value.split(sep).join("/");
+}

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -1,0 +1,1 @@
+export { diagnoseProject, formatDoctorReport } from "./diagnoseProject.js";

--- a/src/infrastructure/compiler/EsbuildCompiler.ts
+++ b/src/infrastructure/compiler/EsbuildCompiler.ts
@@ -1,6 +1,6 @@
 // src/infrastructure/compiler/EsbuildCompiler.ts
 import type esbuild from "esbuild";
-import { watch } from "node:fs";
+import { existsSync, watch } from "node:fs";
 import colors from "colors";
 import { type BuildOptions, context } from "esbuild";
 import { ServerMode } from "../webserver/ServerMode.js";
@@ -12,27 +12,30 @@ import { ProdPlugin } from "../../plugins/ProdEntry.js";
 import { MinifyImagesPlugin } from "../../plugins/MinifyImages.js";
 import { RouterPlugin } from "../../plugins/AppRouter.js";
 import { PostCSSPlugin } from "../../plugins/PostCSSPlugin.js";
+import type { AnastacioConfig } from "../../shared/contracts/index.js";
 
 export class EsbuildCompiler implements IEsbuildCompiler {
+	public config: AnastacioConfig;
 	public entryPoints: string[];
-	public outdir: string;
+	public outfile: string;
 	public mode: ServerMode;
 	private hotReloadServer?: HotReloadServer;
 	private ctx: esbuild.BuildContext | null = null;
 
 	constructor(
-		entryPoints: string[],
-		outdir: string,
+		config: AnastacioConfig,
 		mode: ServerMode,
 		hotReloadServer?: HotReloadServer,
 	) {
-		this.entryPoints = entryPoints;
-		this.outdir = outdir;
+		this.config = config;
+		this.entryPoints = [config.paths.entryFile];
+		this.outfile = config.paths.bundleFile;
 		this.mode = mode;
 		this.hotReloadServer = hotReloadServer;
 	}
 
 	async compile() {
+		this.validateInputs();
 		const plugins = this.getPlugins();
 		const buildOptions = this.getBuildOptions(plugins);
 
@@ -56,18 +59,18 @@ export class EsbuildCompiler implements IEsbuildCompiler {
 		switch (this.mode) {
 			case ServerMode.Development:
 				return [
-					DevPlugin(),
-					RouterPlugin(),
+					DevPlugin(this.config),
+					RouterPlugin(this.config),
 					PostCSSPlugin(), // Pasar el directorio de salida
-					MinifyImagesPlugin(),
+					MinifyImagesPlugin(this.config),
 				];
 			//Como no tenemos mas casos pasamos directo a production mode default
 			default:
 				return [
-					ProdPlugin(),
-					RouterPlugin(),
+					ProdPlugin(this.config),
+					RouterPlugin(this.config),
 					PostCSSPlugin(), // Pasar el directorio de salida
-					MinifyImagesPlugin(),
+					MinifyImagesPlugin(this.config),
 				];
 		}
 	}
@@ -75,7 +78,7 @@ export class EsbuildCompiler implements IEsbuildCompiler {
 	private getBuildOptions(plugins: esbuild.Plugin[]): BuildOptions {
 		return {
 			entryPoints: this.entryPoints,
-			outfile: this.outdir, // Mantener outfile para los archivos JavaScript
+			outfile: this.outfile,
 			bundle: true,
 			minify: this.mode === ServerMode.Production,
 			sourcemap: this.mode === ServerMode.Development,
@@ -89,7 +92,7 @@ export class EsbuildCompiler implements IEsbuildCompiler {
 				".jpeg": "dataurl",
 				".gif": "dataurl",
 				".ico": "dataurl",
-				 ".scss": "text", // Cambiar el loader de .css a .scss para evitar el procesamiento doble
+				".scss": "text",
 			},
 			define: { "process.env.NODE_ENV": `"${this.mode}"` },
 			plugins,
@@ -101,10 +104,14 @@ export class EsbuildCompiler implements IEsbuildCompiler {
 		console.log(formatTime(), "Watching for changes...");
 
 		watch(
-			"src",
+			this.config.paths.srcDir,
 			{ recursive: true, encoding: "utf8" },
 			async (eventType: string, filename: string | null) => {
 				if (filename) {
+					if (filename.replace(/\\/g, "/").endsWith("AppRouter.tsx")) {
+						return;
+					}
+
 					console.log(
 						colors.bgBlack(colors.yellow(`File ${filename} changed.`)),
 					);
@@ -124,6 +131,15 @@ export class EsbuildCompiler implements IEsbuildCompiler {
 		);
 	}
 
+	private validateInputs(): void {
+		if (!existsSync(this.config.paths.entryFile)) {
+			throw new Error(
+				`Entry file not found: ${this.config.paths.entryFile}. ` +
+					"Create the file or configure paths.entryFile in anastacio.config.ts.",
+			);
+		}
+	}
+
 	// Método para compilar el código
 	// ! No existe el método build en la interfaz IEsbuildCompiler
 	// ! Por lo que usamos el método rebuild
@@ -131,6 +147,8 @@ export class EsbuildCompiler implements IEsbuildCompiler {
 		await Timer("Build", async () => {
 			if (this.ctx) {
 				await this.ctx.rebuild();
+				await this.ctx.dispose();
+				this.ctx = null;
 			}
 		});
 		console.log("Build completed successfully.");

--- a/src/infrastructure/compiler/IEsbuildCompiler.ts
+++ b/src/infrastructure/compiler/IEsbuildCompiler.ts
@@ -1,10 +1,12 @@
 // src/infrastructure/compiler/IEsbuildCompiler.ts
 
+import type { AnastacioConfig } from "../../shared/contracts/index.js";
 import type { ServerMode } from "../webserver/ServerMode.js";
 
 export interface IEsbuildCompiler {
+	config: AnastacioConfig;
 	entryPoints: string[];
-	outdir: string;
+	outfile: string;
 	mode: ServerMode;
-	compile(): void;
+	compile(): Promise<void>;
 }

--- a/src/infrastructure/webserver/HttpServer.ts
+++ b/src/infrastructure/webserver/HttpServer.ts
@@ -6,31 +6,38 @@ import { EsbuildCompiler } from "../compiler/EsbuildCompiler.js";
 import type { IHttpServer } from "./IHttpServer.js";
 import type { ServerMode } from "./ServerMode.js";
 import { FindFreePort } from "../../utils/FindFreePort.js";
-import { join } from "node:path";
+import type { AnastacioConfig } from "../../shared/contracts/index.js";
+
+interface HttpServerOverrides {
+	host?: string;
+	port?: number;
+	wsPort?: number;
+}
 
 export class HttpServer implements IHttpServer {
 	private server: http.Server;
 	private hotReloadServer?: HotReloadServer;
 	private compiler: EsbuildCompiler;
 	private freePort = 0;
-	private freeWsPort = 3001;
+	private freeWsPort: number;
+	public hostname: string;
+	public port: number;
+	public wsPort: number;
 
 	constructor(
-		public hostname: string,
-		public port: number,
-		public wsPort: number,
+		public config: AnastacioConfig,
 		public mode: ServerMode,
+		overrides: HttpServerOverrides = {},
 	) {
-		const srcDir = join(process.cwd(), "src");
-		const outputDir = join(process.cwd(), "dist");
-		this.server = http.createServer(staticFileController(outputDir)); // Pasar el directorio de salida al controlador
-		this.hotReloadServer = new HotReloadServer(wsPort);
-		this.compiler = new EsbuildCompiler(
-			[`${srcDir}/index.tsx`],
-			join(outputDir, "bundler.js"),
-			mode,
-			this.hotReloadServer,
+		this.hostname = overrides.host ?? config.dev.host;
+		this.port = overrides.port ?? config.dev.port;
+		this.wsPort = overrides.wsPort ?? config.dev.wsPort;
+		this.freeWsPort = this.wsPort;
+		this.server = http.createServer(
+			staticFileController(config.paths.outDir),
 		);
+		this.hotReloadServer = new HotReloadServer(this.wsPort);
+		this.compiler = new EsbuildCompiler(config, mode, this.hotReloadServer);
 	}
 
 	async init() {
@@ -50,7 +57,7 @@ export class HttpServer implements IHttpServer {
 	}
 
 	start() {
-		this.init();
+		void this.init();
 	}
 
 	notifyClients() {

--- a/src/infrastructure/webserver/IHttpServer.ts
+++ b/src/infrastructure/webserver/IHttpServer.ts
@@ -5,9 +5,9 @@ export interface IHttpServer {
 	hostname: string;
 	port: number;
 	mode: ServerMode;
-	init(): void;
+	init(): Promise<void>;
 	start(): void;
 	notifyClients(): void;
 	closeServers(): void;
-	handleSessionStop(signal: string): void;
+	handleSessionStop(signal: string): Promise<void>;
 }

--- a/src/inspector/index.ts
+++ b/src/inspector/index.ts
@@ -1,0 +1,4 @@
+export {
+	formatInspectionReport,
+	inspectProject,
+} from "./inspectProject.js";

--- a/src/inspector/inspectProject.ts
+++ b/src/inspector/inspectProject.ts
@@ -1,0 +1,133 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import { createFrameworkContext } from "../core/index.js";
+import { writeRoutesManifest } from "../router/index.js";
+import type {
+	AnastacioConfig,
+	RouteDefinition,
+} from "../shared/contracts/index.js";
+
+export interface InspectionReport {
+	rootDir: string;
+	paths: {
+		appDir: string;
+		entryFile: string;
+		outDir: string;
+		internalDir: string;
+	};
+	artifacts: {
+		routesManifest: string;
+		projectContext: string;
+	};
+	routes: RouteDefinition[];
+}
+
+export async function inspectProject(
+	projectRoot = process.cwd(),
+): Promise<InspectionReport> {
+	const framework = await createFrameworkContext(projectRoot);
+	const { config, routes } = framework;
+	const routesManifestPath = writeRoutesManifest(config, routes);
+	const projectContextPath = writeProjectContext(config, routes);
+
+	return {
+		rootDir: config.rootDir,
+		paths: {
+			appDir: toProjectRelative(config.rootDir, config.paths.appDir),
+			entryFile: toProjectRelative(config.rootDir, config.paths.entryFile),
+			outDir: toProjectRelative(config.rootDir, config.paths.outDir),
+			internalDir: toProjectRelative(config.rootDir, config.paths.internalDir),
+		},
+		artifacts: {
+			routesManifest: toProjectRelative(config.rootDir, routesManifestPath),
+			projectContext: toProjectRelative(config.rootDir, projectContextPath),
+		},
+		routes,
+	};
+}
+
+export function formatInspectionReport(report: InspectionReport): string {
+	const lines = [
+		"Anastacio Inspect",
+		`root: ${report.rootDir}`,
+		`appDir: ${report.paths.appDir}`,
+		`entryFile: ${report.paths.entryFile}`,
+		`outDir: ${report.paths.outDir}`,
+		`routes: ${report.routes.length}`,
+		`routes.manifest.json: ${report.artifacts.routesManifest}`,
+		`project-context.md: ${report.artifacts.projectContext}`,
+	];
+
+	if (report.routes.length === 0) {
+		lines.push("No routes were detected.");
+		return lines.join("\n");
+	}
+
+	lines.push("");
+	for (const route of report.routes) {
+		lines.push(
+			`${route.path} -> ${route.file}${route.layout ? ` [layout: ${route.layout}]` : ""}`,
+		);
+	}
+
+	return lines.join("\n");
+}
+
+function writeProjectContext(
+	config: AnastacioConfig,
+	routes: RouteDefinition[],
+): string {
+	mkdirSync(config.paths.internalDir, { recursive: true });
+
+	const outputPath = join(config.paths.internalDir, "project-context.md");
+	const lines = [
+		"# Anastacio Project Context",
+		"",
+		"## Structure",
+		"",
+		`- root: \`${config.rootDir}\``,
+		`- appDir: \`${toProjectRelative(config.rootDir, config.paths.appDir)}\``,
+		`- entryFile: \`${toProjectRelative(config.rootDir, config.paths.entryFile)}\``,
+		`- outDir: \`${toProjectRelative(config.rootDir, config.paths.outDir)}\``,
+		"",
+		"## Routes",
+		"",
+	];
+
+	if (routes.length === 0) {
+		lines.push("- No routes detected.");
+	} else {
+		for (const route of routes) {
+			const details = [
+				`path: \`${route.path}\``,
+				`file: \`${route.file}\``,
+				...(route.layout ? [`layout: \`${route.layout}\``] : []),
+				...(route.dynamicParams?.length
+					? [`params: \`${route.dynamicParams.join(", ")}\``]
+					: []),
+			];
+			lines.push(`- ${details.join(" | ")}`);
+		}
+	}
+
+	lines.push("");
+	lines.push("## Conventions");
+	lines.push("");
+	lines.push(
+		`- File-based routing under \`${toProjectRelative(config.rootDir, config.paths.appDir)}\` by default.`,
+	);
+	lines.push("- Layout inheritance uses the nearest `layout.tsx`.");
+	lines.push("- Route manifests are written to `.anastacio/`.");
+
+	writeFileSync(outputPath, `${lines.join("\n")}\n`, "utf8");
+
+	return outputPath;
+}
+
+function toProjectRelative(projectRoot: string, filePath: string): string {
+	return normalizePath(relative(projectRoot, filePath));
+}
+
+function normalizePath(value: string): string {
+	return value.split(sep).join("/");
+}

--- a/src/plugins/AppRouter.ts
+++ b/src/plugins/AppRouter.ts
@@ -1,193 +1,30 @@
 import type { Plugin } from "esbuild";
-import { readdirSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
-import type { Dirent } from "node:fs";
-import { join, parse, relative } from "node:path";
+import { existsSync, mkdirSync } from "node:fs";
+import { relative } from "node:path";
+import {
+	resolveRoutes,
+	writeGeneratedAppRouter,
+	writeRoutesManifest,
+} from "../router/index.js";
+import type { AnastacioConfig } from "../shared/contracts/index.js";
 
-export const RouterPlugin = (): Plugin => ({
+export const RouterPlugin = (config: AnastacioConfig): Plugin => ({
 	name: "router-plugin",
 	setup(build) {
 		build.onStart(() => {
-			const srcDir = join(process.cwd(), "src");
-			const appDir = join(srcDir, "app");
-			const outputDir = join(process.cwd(), "src");
-			const outputFile = join(outputDir, "AppRouter.tsx");
-
-			if (!existsSync(appDir)) {
-				throw new Error("The App directory does not exist.");
+			if (!existsSync(config.paths.appDir)) {
+				throw new Error(
+					`The app directory does not exist: ${relative(config.rootDir, config.paths.appDir)}.`,
+				);
 			}
 
-			if (!existsSync(outputDir)) {
-				mkdirSync(outputDir, { recursive: true });
+			if (!existsSync(config.paths.srcDir)) {
+				mkdirSync(config.paths.srcDir, { recursive: true });
 			}
 
-			const lazyImports: string[] = [];
-			const routesImports: string[] = [];
-			handleLazyImports(lazyImports, appDir, srcDir, routesImports);
-
-			const routerContent = createRouterContent(lazyImports, routesImports);
-			writeFileSync(outputFile, routerContent);
+			const routes = resolveRoutes(config);
+			writeRoutesManifest(config, routes);
+			writeGeneratedAppRouter(config, routes);
 		});
 	},
 });
-
-const handleLazyImports = (
-	imports: string[],
-	appDir: string,
-	srcDir: string,
-	routesImports: string[],
-	relativePath = "",
-): string[] => {
-	const files = readdirSync(appDir, { withFileTypes: true });
-	const componentNames: string[] = [];
-
-	for (const file of files) {
-		if (file.isDirectory()) {
-			const childComponentNames = handleLazyImports(
-				imports,
-				join(appDir, file.name),
-				srcDir,
-				routesImports,
-				`${relativePath}/${file.name}`,
-			);
-			componentNames.push(...childComponentNames);
-			if (childComponentNames.length === 0) continue;
-
-			const { parentRoute, childRoutes, closeRoute } = createRoutes(
-				file.name,
-				childComponentNames,
-				relativePath,
-			);
-			const finalRoute = parentRoute
-				? `${parentRoute}\n${childRoutes.join("\n")}\n${closeRoute}`
-				: `<Route path="${relativePath}/${file.name}" element={<${childComponentNames[0]} />} />`;
-			routesImports.push(finalRoute);
-		} else {
-			const componentName = processFile(
-				file,
-				appDir,
-				srcDir,
-				imports,
-				routesImports,
-				relativePath,
-			);
-			if (componentName) componentNames.push(componentName);
-		}
-	}
-
-	return componentNames;
-};
-
-const processFile = (
-	file: Dirent,
-	appDir: string,
-	srcDir: string,
-	imports: string[],
-	routesImports: string[],
-	relativePath: string,
-): string | null => {
-	const tempfile = parse(file.name);
-	if (tempfile.ext === ".tsx" || tempfile.ext === ".jsx") {
-		const relPath = relative(
-			srcDir,
-			join(appDir, tempfile.dir, tempfile.name),
-		).replace(/\\/g, "/");
-		const componentName = formatComponentName(relPath);
-
-		// Excluir componentes específicos de la importación dinámica
-		if (
-			[
-				"Apppage",
-				"Applayout",
-				"Apploading",
-				"Appnotfound",
-				"ApperrorPage",
-			].includes(componentName)
-		) {
-			return null;
-		}
-
-		imports.push(`const ${componentName} = lazy(() => import('${relPath}'));`);
-
-		// Handle dynamic routes
-		const routePath = relativePath
-			? `${relativePath}/${tempfile.name.replace(/\[(.+?)\]/g, ":$1")}`
-			: tempfile.name.replace(/\[(.+?)\]/g, ":$1");
-
-		routesImports.push(
-			`<Route path="${routePath}" element={<${componentName} />} />`,
-		);
-		return componentName;
-	}
-	return null;
-};
-
-const formatComponentName = (relPath: string): string => {
-	const componentName = relPath
-		.replace(/^\.\/app\//, "")
-		.replace(/\//g, "")
-		.replace(/\./g, "");
-	return componentName.charAt(0).toUpperCase() + componentName.slice(1);
-};
-
-const createRoutes = (
-	folderName: string,
-	childComponentNames: string[],
-	relativePath: string,
-): { parentRoute: string; childRoutes: string[]; closeRoute: string } => {
-	let parentRoute = "";
-	const childRoutes: string[] = [];
-	let closeRoute = "";
-
-	for (const component of childComponentNames) {
-		if (component.toLowerCase().includes("layout")) {
-			parentRoute = `<Route path="${relativePath}/${folderName}" element={<${component} />}>`;
-			continue;
-		}
-		if (component.toLowerCase().includes("page")) {
-			childRoutes.push(`<Route index element={<${component} />} />`);
-		} else {
-			childRoutes.push(
-				`<Route path="${component.toLowerCase()}" element={<${component} />} />`,
-			);
-		}
-	}
-
-	if (parentRoute !== "") {
-		closeRoute = "</Route>";
-	}
-
-	return { parentRoute, childRoutes, closeRoute };
-};
-
-const createRouterContent = (
-	lazyImports: string[],
-	routesImports: string[],
-): string => `
-import React, { Suspense, lazy } from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import ErrorBoundary from './components/ErrorBoundary';
-
-const ApperrorPage = lazy(() => import('app/errorPage'));
-const Applayout = lazy(() => import('app/layout'));
-const Apploading = lazy(() => import('app/loading'));
-const Appnotfound = lazy(() => import('app/notfound'));
-const Apppage = lazy(() => import('app/page'));
-${lazyImports.join("\n")}
-
-const AppRouter = () => (
-  <Router>
-   <ErrorBoundary>
-    <Suspense fallback={<Apploading />}>
-      <Routes>
-       <Route path="/" element={<Applayout />}>
-       <Route index element={<Apppage />} />
-       ${routesImports.join("\n")}
-       </Route>
-       <Route path="*" element={<Appnotfound />} />
-      </Routes>
-    </Suspense>
-   </ErrorBoundary>
-  </Router>
-);
-
-export default AppRouter`;

--- a/src/plugins/DevEntry.ts
+++ b/src/plugins/DevEntry.ts
@@ -2,8 +2,9 @@ import type { Plugin } from "esbuild";
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
+import type { AnastacioConfig } from "../shared/contracts/index.js";
 
-export const DevPlugin = (): Plugin => ({
+export const DevPlugin = (config: AnastacioConfig): Plugin => ({
 	name: "dev-plugin",
 	setup(build) {
 		build.onEnd(() => {
@@ -21,7 +22,7 @@ export const DevPlugin = (): Plugin => ({
   <script src="bundler.js"></script>
   <script>
     // Conectar al servidor WebSocket
-    const ws = new WebSocket("ws://localhost:3001");
+    const ws = new WebSocket("ws://${config.dev.host}:${config.dev.wsPort}");
 
     // Escuchar mensajes del servidor WebSocket
     ws.onmessage = (event) => {
@@ -44,7 +45,7 @@ export const DevPlugin = (): Plugin => ({
 </body>
 </html>
             `;
-			const htmlPath = join(process.cwd(), "dist/index.html");
+			const htmlPath = join(config.paths.outDir, "index.html");
 
 			writeHtmlIfChanged(htmlPath, htmlContent).catch((error) =>
 				console.error("Error handling HTML file:", error),

--- a/src/plugins/MinifyImages.ts
+++ b/src/plugins/MinifyImages.ts
@@ -13,16 +13,21 @@ import {
 import { join, extname, basename } from "node:path";
 import sharp from "sharp";
 import { Timer } from "../utils/Timer.js";
+import type { AnastacioConfig } from "../shared/contracts/index.js";
 
-export const MinifyImagesPlugin = (): Plugin => ({
+export const MinifyImagesPlugin = (config: AnastacioConfig): Plugin => ({
 	name: "minify-images-plugin",
 	setup(build) {
 		build.onEnd(async () => {
 			await Timer("Image minification and conversion", async () => {
-				const srcDir = join(process.cwd(), "src/public");
-				const outputDir = join(process.cwd(), "dist/public");
+				const srcDir = config.paths.publicDir;
+				const outputDir = join(config.paths.outDir, "public");
 				const imageExtensions = [".jpg", ".jpeg", ".png", ".svg", ".gif"];
 				const convertibleExtensions = [".jpg", ".jpeg", ".png"];
+
+				if (!existsSync(srcDir)) {
+					return;
+				}
 
 				// Crear el directorio de salida si no existe
 				if (!existsSync(outputDir)) {

--- a/src/plugins/ProdEntry.ts
+++ b/src/plugins/ProdEntry.ts
@@ -2,12 +2,13 @@ import type { Plugin } from "esbuild";
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
+import type { AnastacioConfig } from "../shared/contracts/index.js";
 
-export const ProdPlugin = (): Plugin => ({
+export const ProdPlugin = (config: AnastacioConfig): Plugin => ({
 	name: "prod-plugin",
 	setup(build) {
 		build.onEnd(async () => {
-			const outputDir = join(process.cwd(), "dist");
+			const outputDir = config.paths.outDir;
 			// Crear el archivo HTML
 			const htmlContent = `
 <!DOCTYPE html>

--- a/src/router/generateAppRouter.ts
+++ b/src/router/generateAppRouter.ts
@@ -1,0 +1,222 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { join, parse, relative, resolve } from "node:path";
+import type { AnastacioConfig, RouteDefinition } from "../shared/contracts/index.js";
+
+const LOADING_FILE_NAMES = ["loading.tsx", "loading.jsx"];
+const NOT_FOUND_FILE_NAMES = [
+	"notfound.tsx",
+	"notfound.jsx",
+	"not-found.tsx",
+	"not-found.jsx",
+];
+const ERROR_FILE_NAMES = [
+	"error.tsx",
+	"error.jsx",
+	"errorPage.tsx",
+	"errorPage.jsx",
+];
+
+export function writeGeneratedAppRouter(
+	config: AnastacioConfig,
+	routes: RouteDefinition[],
+): string {
+	const outputPath = join(config.paths.srcDir, "AppRouter.tsx");
+	const source = createAppRouterSource(config, routes);
+	writeFileSync(outputPath, source, "utf8");
+	return outputPath;
+}
+
+export function createAppRouterSource(
+	config: AnastacioConfig,
+	routes: RouteDefinition[],
+): string {
+	const pageImports = new Map<string, string>();
+	const layoutImports = new Map<string, string>();
+	const directRoutes: string[] = [];
+	const layoutGroups = new Map<string, string[]>();
+
+	for (const route of routes) {
+		const pageComponent = registerComponentImport(
+			pageImports,
+			"RoutePage",
+			config,
+			route.file,
+		);
+		const routeLine = `        <Route path="${route.path}" element={<${pageComponent} />} />`;
+
+		if (route.layout) {
+			const layoutComponent = registerComponentImport(
+				layoutImports,
+				"RouteLayout",
+				config,
+				route.layout,
+			);
+			const layoutRoutes = layoutGroups.get(layoutComponent) ?? [];
+			layoutRoutes.push(routeLine);
+			layoutGroups.set(layoutComponent, layoutRoutes);
+			continue;
+		}
+
+		directRoutes.push(routeLine);
+	}
+
+	const groupedLayoutRoutes = Array.from(layoutGroups.entries()).map(
+		([layoutComponent, routeLines]) => `      <Route element={<${layoutComponent} />}>
+${routeLines.join("\n")}
+      </Route>`,
+	);
+
+	const componentImports = [
+		...createRootComponentDefinitions(config),
+		...serializeImports(pageImports),
+		...serializeImports(layoutImports),
+	];
+
+	return `
+import React, { Suspense, lazy } from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <ApperrorPage />;
+    }
+
+    return this.props.children;
+  }
+}
+
+${componentImports.join("\n")}
+
+const AppRouter = () => (
+  <Router>
+    <ErrorBoundary>
+      <Suspense fallback={<Apploading />}>
+        <Routes>
+${directRoutes.join("\n")}
+${groupedLayoutRoutes.join("\n")}
+          <Route path="*" element={<Appnotfound />} />
+        </Routes>
+      </Suspense>
+    </ErrorBoundary>
+  </Router>
+);
+
+export default AppRouter;
+`;
+}
+
+function createRootComponentDefinitions(config: AnastacioConfig): string[] {
+	return [
+		createLazyOrFallbackComponent(
+			config,
+			LOADING_FILE_NAMES,
+			"Apploading",
+			"const Apploading = () => null;",
+		),
+		createLazyOrFallbackComponent(
+			config,
+			NOT_FOUND_FILE_NAMES,
+			"Appnotfound",
+			"const Appnotfound = () => null;",
+		),
+		createLazyOrFallbackComponent(
+			config,
+			ERROR_FILE_NAMES,
+			"ApperrorPage",
+			"const ApperrorPage = () => null;",
+		),
+	];
+}
+
+function createLazyOrFallbackComponent(
+	config: AnastacioConfig,
+	fileNames: string[],
+	componentName: string,
+	fallbackDefinition: string,
+): string {
+	const existingFile = findFirstExistingFile(config.paths.appDir, fileNames);
+
+	if (!existingFile) {
+		return fallbackDefinition;
+	}
+
+	const importPath = toImportSpecifier(config.paths.srcDir, existingFile);
+	return `const ${componentName} = lazy(() => import('${importPath}'));`;
+}
+
+function findFirstExistingFile(
+	directory: string,
+	fileNames: string[],
+): string | undefined {
+	for (const fileName of fileNames) {
+		const candidate = join(directory, fileName);
+		if (existsSync(candidate)) {
+			return candidate;
+		}
+	}
+
+	return undefined;
+}
+
+function registerComponentImport(
+	imports: Map<string, string>,
+	prefix: string,
+	config: AnastacioConfig,
+	projectRelativeFilePath: string,
+): string {
+	const absoluteFilePath = resolve(config.rootDir, projectRelativeFilePath);
+	const importPath = toImportSpecifier(config.paths.srcDir, absoluteFilePath);
+	const existing = imports.get(importPath);
+
+	if (existing) {
+		return existing;
+	}
+
+	const componentName = toComponentName(prefix, importPath);
+	imports.set(importPath, componentName);
+	return componentName;
+}
+
+function serializeImports(imports: Map<string, string>): string[] {
+	return Array.from(imports.entries())
+		.sort(([leftPath], [rightPath]) => leftPath.localeCompare(rightPath))
+		.map(
+			([importPath, componentName]) =>
+				`const ${componentName} = lazy(() => import('${importPath}'));`,
+		);
+}
+
+function toImportSpecifier(srcDir: string, absoluteFilePath: string): string {
+	const relativePath = relative(srcDir, absoluteFilePath).replace(/\\/g, "/");
+	const parsedPath = parse(relativePath);
+	const pathWithoutExtension = join(parsedPath.dir, parsedPath.name).replace(
+		/\\/g,
+		"/",
+	);
+
+	return pathWithoutExtension.startsWith(".")
+		? pathWithoutExtension
+		: `./${pathWithoutExtension}`;
+}
+
+function toComponentName(prefix: string, importPath: string): string {
+	const suffix = importPath
+		.replace(/[^a-zA-Z0-9]+/g, " ")
+		.trim()
+		.split(/\s+/)
+		.filter(Boolean)
+		.map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+		.join("");
+
+	return `${prefix}${suffix}`;
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,0 +1,3 @@
+export { createAppRouterSource, writeGeneratedAppRouter } from "./generateAppRouter.js";
+export { resolveRoutes } from "./resolveRoutes.js";
+export { writeRoutesManifest } from "./writeRoutesManifest.js";

--- a/src/router/resolveRoutes.ts
+++ b/src/router/resolveRoutes.ts
@@ -1,0 +1,149 @@
+import { existsSync, readdirSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import type {
+	AnastacioConfig,
+	RouteDefinition,
+} from "../shared/contracts/index.js";
+
+const PAGE_FILE_NAMES = ["page.tsx", "page.jsx"];
+const LAYOUT_FILE_NAMES = ["layout.tsx", "layout.jsx"];
+const LOADING_FILE_NAMES = ["loading.tsx", "loading.jsx"];
+const ERROR_FILE_NAMES = [
+	"error.tsx",
+	"error.jsx",
+	"errorPage.tsx",
+	"errorPage.jsx",
+];
+const NOT_FOUND_FILE_NAMES = [
+	"notfound.tsx",
+	"notfound.jsx",
+	"not-found.tsx",
+	"not-found.jsx",
+];
+
+export function resolveRoutes(config: AnastacioConfig): RouteDefinition[] {
+	if (!existsSync(config.paths.appDir)) {
+		return [];
+	}
+
+	return walkRoutes(config.paths.appDir, config).sort(sortRoutes);
+}
+
+function walkRoutes(
+	currentDirectory: string,
+	config: AnastacioConfig,
+	inheritedLayout?: string,
+): RouteDefinition[] {
+	const entries = readdirSync(currentDirectory, {
+		withFileTypes: true,
+	}).sort((left, right) => left.name.localeCompare(right.name));
+	const currentLayout =
+		findKnownFile(currentDirectory, LAYOUT_FILE_NAMES) ?? inheritedLayout;
+	const routes: RouteDefinition[] = [];
+	const pageFile = findKnownFile(currentDirectory, PAGE_FILE_NAMES);
+
+	if (pageFile) {
+		routes.push(
+			createRouteDefinition(config, currentDirectory, pageFile, currentLayout),
+		);
+	}
+
+	for (const entry of entries) {
+		if (!entry.isDirectory()) {
+			continue;
+		}
+
+		routes.push(
+			...walkRoutes(join(currentDirectory, entry.name), config, currentLayout),
+		);
+	}
+
+	return routes;
+}
+
+function createRouteDefinition(
+	config: AnastacioConfig,
+	currentDirectory: string,
+	pageFile: string,
+	layoutFile?: string,
+): RouteDefinition {
+	const relativeDirectory = normalizePath(
+		relative(config.paths.appDir, currentDirectory),
+	);
+	const segments = relativeDirectory ? relativeDirectory.split("/") : [];
+	const dynamicParams = segments
+		.filter(isDynamicSegment)
+		.map((segment) => stripDynamicSegment(segment));
+
+	return {
+		path: toRoutePath(segments),
+		file: toProjectRelative(config.rootDir, pageFile),
+		...(layoutFile ? { layout: toProjectRelative(config.rootDir, layoutFile) } : {}),
+		...(dynamicParams.length > 0 ? { dynamicParams } : {}),
+		hasLoading: hasKnownFile(currentDirectory, LOADING_FILE_NAMES),
+		hasErrorBoundary: hasKnownFile(currentDirectory, ERROR_FILE_NAMES),
+		hasNotFound: hasKnownFile(currentDirectory, NOT_FOUND_FILE_NAMES),
+	};
+}
+
+function toRoutePath(segments: string[]): string {
+	if (segments.length === 0) {
+		return "/";
+	}
+
+	return `/${segments.map(formatRouteSegment).join("/")}`;
+}
+
+function formatRouteSegment(segment: string): string {
+	if (isDynamicSegment(segment)) {
+		return `:${stripDynamicSegment(segment)}`;
+	}
+
+	return segment;
+}
+
+function isDynamicSegment(segment: string): boolean {
+	return segment.startsWith("[") && segment.endsWith("]");
+}
+
+function stripDynamicSegment(segment: string): string {
+	return segment.slice(1, -1);
+}
+
+function findKnownFile(
+	directory: string,
+	fileNames: string[],
+): string | undefined {
+	for (const fileName of fileNames) {
+		const candidate = join(directory, fileName);
+		if (existsSync(candidate)) {
+			return candidate;
+		}
+	}
+
+	return undefined;
+}
+
+function hasKnownFile(directory: string, fileNames: string[]): boolean {
+	return findKnownFile(directory, fileNames) !== undefined;
+}
+
+function sortRoutes(left: RouteDefinition, right: RouteDefinition): number {
+	if (left.path === "/") {
+		return -1;
+	}
+
+	if (right.path === "/") {
+		return 1;
+	}
+
+	return left.path.localeCompare(right.path) || left.file.localeCompare(right.file);
+}
+
+function normalizePath(value: string): string {
+	return value.split(sep).join("/");
+}
+
+function toProjectRelative(projectRoot: string, filePath: string): string {
+	return normalizePath(relative(projectRoot, filePath));
+}

--- a/src/router/writeRoutesManifest.ts
+++ b/src/router/writeRoutesManifest.ts
@@ -1,0 +1,30 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import type {
+	AnastacioConfig,
+	RouteDefinition,
+	RoutesManifest,
+} from "../shared/contracts/index.js";
+
+export function writeRoutesManifest(
+	config: AnastacioConfig,
+	routes: RouteDefinition[],
+): string {
+	mkdirSync(config.paths.internalDir, { recursive: true });
+
+	const manifestPath = join(config.paths.internalDir, "routes.manifest.json");
+	const manifest: RoutesManifest = {
+		kind: "routes-manifest",
+		version: 1,
+		appDir: normalizePath(relative(config.rootDir, config.paths.appDir)),
+		routes,
+	};
+
+	writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+
+	return manifestPath;
+}
+
+function normalizePath(value: string): string {
+	return value.split(sep).join("/");
+}

--- a/src/shared/contracts/config.ts
+++ b/src/shared/contracts/config.ts
@@ -1,0 +1,36 @@
+export interface AnastacioDevConfig {
+	host: string;
+	port: number;
+	wsPort: number;
+}
+
+export interface AnastacioPathsConfig {
+	srcDir: string;
+	appDir: string;
+	publicDir: string;
+	outDir: string;
+	entryFile: string;
+	internalDir: string;
+	bundleFile: string;
+}
+
+export interface AnastacioConfig {
+	rootDir: string;
+	paths: AnastacioPathsConfig;
+	dev: AnastacioDevConfig;
+}
+
+export interface AnastacioUserPathsConfig {
+	srcDir?: string;
+	appDir?: string;
+	publicDir?: string;
+	outDir?: string;
+	entryFile?: string;
+	internalDir?: string;
+	bundleFile?: string;
+}
+
+export interface AnastacioUserConfig {
+	paths?: AnastacioUserPathsConfig;
+	dev?: Partial<AnastacioDevConfig>;
+}

--- a/src/shared/contracts/diagnostics.ts
+++ b/src/shared/contracts/diagnostics.ts
@@ -1,0 +1,13 @@
+export interface Diagnostic {
+	code: string;
+	severity: "error" | "warning" | "info";
+	message: string;
+	file?: string;
+	suggestion?: string;
+}
+
+export interface DiagnosticReport {
+	kind: "diagnostic-report";
+	version: 1;
+	diagnostics: Diagnostic[];
+}

--- a/src/shared/contracts/index.ts
+++ b/src/shared/contracts/index.ts
@@ -1,0 +1,15 @@
+export type {
+	AnastacioConfig,
+	AnastacioDevConfig,
+	AnastacioPathsConfig,
+	AnastacioUserConfig,
+	AnastacioUserPathsConfig,
+} from "./config.js";
+export type { Diagnostic, DiagnosticReport } from "./diagnostics.js";
+export type {
+	AnastacioPlugin,
+	BuildContext,
+	BuildResult,
+	FrameworkContext,
+} from "./plugin.js";
+export type { RouteDefinition, RoutesManifest } from "./routes.js";

--- a/src/shared/contracts/plugin.ts
+++ b/src/shared/contracts/plugin.ts
@@ -1,0 +1,29 @@
+import type { AnastacioConfig } from "./config.js";
+import type { DiagnosticReport } from "./diagnostics.js";
+import type { RouteDefinition } from "./routes.js";
+
+export interface FrameworkContext {
+	projectRoot: string;
+	config: AnastacioConfig;
+}
+
+export interface BuildContext extends FrameworkContext {
+	mode: string;
+	entryPoints: string[];
+	outfile: string;
+}
+
+export interface BuildResult {
+	mode: string;
+	outfile: string;
+}
+
+export interface AnastacioPlugin {
+	name: string;
+	setup?(context: FrameworkContext): Promise<void> | void;
+	onConfigResolved?(config: AnastacioConfig): Promise<void> | void;
+	onRoutesResolved?(routes: RouteDefinition[]): Promise<void> | void;
+	onBuildStart?(ctx: BuildContext): Promise<void> | void;
+	onBuildEnd?(result: BuildResult): Promise<void> | void;
+	onDiagnostics?(report: DiagnosticReport): Promise<void> | void;
+}

--- a/src/shared/contracts/routes.ts
+++ b/src/shared/contracts/routes.ts
@@ -1,0 +1,16 @@
+export interface RouteDefinition {
+	path: string;
+	file: string;
+	layout?: string;
+	dynamicParams?: string[];
+	hasLoading?: boolean;
+	hasErrorBoundary?: boolean;
+	hasNotFound?: boolean;
+}
+
+export interface RoutesManifest {
+	kind: "routes-manifest";
+	version: 1;
+	appDir: string;
+	routes: RouteDefinition[];
+}


### PR DESCRIPTION
## Summary
- align v2 commands around a shared framework context
- move AppRouter generation under the canonical router module
- add inspect/doctor/core/router/shared foundations for Anastacio v2
- add basic example app fixture for validation
- document official v2 architecture and ignore sensitive recovery codes

## Validation
- npm run build
- node dist/bin/cli.js inspect --root examples/basic-app --json
- node dist/bin/cli.js doctor --root examples/basic-app --json

## Notes
This PR targets `dev`, which now carries the Anastacio v2 baseline.