### PR TITLE
ci: update main branch workflows for v2 validation and npm release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - feat/**
+  pull_request:
+    branches:
+      - main
+      - dev
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.10.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install oxlint Linux binding
+        run: npm install --no-save @oxlint/binding-linux-x64-gnu@1.56.0
+
+      - name: Lint code
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Build project
+        run: npm run build
+
+      - name: Pack npm tarball
+        run: npm pack --dry-run

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,94 +1,11 @@
-# .github/workflows/main.yml
-name: main
+name: legacy-main-ci
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
-  hot-cache:
+  migrated:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Cache Node.js modules
-        id: cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '22.10.0'
-
-      - name: Install dependencies
-        run: npm install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-
-  lint-and-format:
-    runs-on: ubuntu-latest
-    needs: [hot-cache]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Cache Node.js modules
-        id: cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '22.10.0'
-
-      - name: Install dependencies
-        run: npm install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-
-      - name: Lint code
-        run: npm run lint
-
-      - name: Format code
-        run: npm run format
-
-  build:
-    runs-on: ubuntu-latest
-    needs: [hot-cache]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Cache Node.js modules
-        id: cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '22.10.0'
-
-      - name: Install dependencies
-        run: npm install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-
-      - name: Build project
-        run: npm run build
+      - name: CI migrated to ci.yml
+        run: echo "This workflow has been superseded by .github/workflows/ci.yml"

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,66 @@
+name: release-npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: npm dist-tag to publish under
+        required: true
+        default: latest
+      access:
+        description: npm access level
+        required: true
+        default: public
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.10.0
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install oxlint Linux binding
+        run: npm install --no-save @oxlint/binding-linux-x64-gnu@1.56.0
+
+      - name: Validate package
+        run: npm run lint && npm run format:check && npm run build
+
+      - name: Verify package version is publishable
+        shell: bash
+        run: |
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          PUBLISHED_VERSION=$(npm view "$PACKAGE_NAME" version 2>/dev/null || true)
+          echo "package=$PACKAGE_NAME version=$PACKAGE_VERSION published=${PUBLISHED_VERSION:-<none>}"
+          if [ "$PACKAGE_VERSION" = "$PUBLISHED_VERSION" ]; then
+            echo "Version $PACKAGE_VERSION is already published for $PACKAGE_NAME"
+            exit 1
+          fi
+
+      - name: Publish to npm (manual)
+        if: github.event_name == 'workflow_dispatch'
+        run: npm publish --access "${{ github.event.inputs.access }}" --tag "${{ github.event.inputs.tag }}" --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm (tag push)
+        if: github.event_name == 'push'
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- replace the legacy main workflow with a manual stub
- add the shared CI workflow used by v2 branches
- add the npm release workflow for tag/manual publishing
- install the oxlint Linux binding explicitly in GitHub Actions

## Why
PRs targeting `main` evaluate workflows from `main`, so `main` must receive the updated workflow files before the larger `dev -> main` PR can validate correctly.