### PR TITLE
feat: continue Anastacio v2 migration on dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Install oxlint Linux binding
+        run: npm install --no-save @oxlint/binding-linux-x64-gnu@1.56.0
+
       - name: Lint code
         run: npm run lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Lint code
         run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - feat/**
+  pull_request:
+    branches:
+      - main
+      - dev
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.10.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint code
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Build project
+        run: npm run build
+
+      - name: Pack npm tarball
+        run: npm pack --dry-run

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,94 +1,11 @@
-# .github/workflows/main.yml
-name: main
+name: legacy-main-ci
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
-  hot-cache:
+  migrated:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Cache Node.js modules
-        id: cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '22.10.0'
-
-      - name: Install dependencies
-        run: npm install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-
-  lint-and-format:
-    runs-on: ubuntu-latest
-    needs: [hot-cache]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Cache Node.js modules
-        id: cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '22.10.0'
-
-      - name: Install dependencies
-        run: npm install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-
-      - name: Lint code
-        run: npm run lint
-
-      - name: Format code
-        run: npm run format
-
-  build:
-    runs-on: ubuntu-latest
-    needs: [hot-cache]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Cache Node.js modules
-        id: cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '22.10.0'
-
-      - name: Install dependencies
-        run: npm install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-
-      - name: Build project
-        run: npm run build
+      - name: CI migrated to ci.yml
+        run: echo "This workflow has been superseded by .github/workflows/ci.yml"

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -33,7 +33,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Validate package
         run: npm run lint && npm run format:check && npm run build

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Install oxlint Linux binding
+        run: npm install --no-save @oxlint/binding-linux-x64-gnu@1.56.0
+
       - name: Validate package
         run: npm run lint && npm run format:check && npm run build
 

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,63 @@
+name: release-npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: npm dist-tag to publish under
+        required: true
+        default: latest
+      access:
+        description: npm access level
+        required: true
+        default: public
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.10.0
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate package
+        run: npm run lint && npm run format:check && npm run build
+
+      - name: Verify package version is publishable
+        shell: bash
+        run: |
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          PUBLISHED_VERSION=$(npm view "$PACKAGE_NAME" version 2>/dev/null || true)
+          echo "package=$PACKAGE_NAME version=$PACKAGE_VERSION published=${PUBLISHED_VERSION:-<none>}"
+          if [ "$PACKAGE_VERSION" = "$PUBLISHED_VERSION" ]; then
+            echo "Version $PACKAGE_VERSION is already published for $PACKAGE_NAME"
+            exit 1
+          fi
+
+      - name: Publish to npm (manual)
+        if: github.event_name == 'workflow_dispatch'
+        run: npm publish --access "${{ github.event.inputs.access }}" --tag "${{ github.event.inputs.tag }}" --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm (tag push)
+        if: github.event_name == 'push'
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -94,7 +94,30 @@ Mientras el core de v2 madura, estos scripts siguen disponibles:
 npm run build
 npm run lint
 npm run format
+npm run format:check
 ```
+
+## CI y releases
+
+El repositorio ahora separa validacion y publicacion:
+
+- `ci.yml` valida lint, formato, build y `npm pack --dry-run`
+- `release-npm.yml` publica a npm por tag `v*` o por `workflow_dispatch`
+
+### Requisitos para publicar a npm
+
+Configura este secret en GitHub Actions:
+
+- `NPM_TOKEN`
+
+### Flujo recomendado de release
+
+1. actualizar `package.json` con una version no publicada;
+2. mergear a la rama objetivo;
+3. crear un tag tipo `v0.0.52` y empujarlo al remoto, o lanzar `release-npm.yml` manualmente;
+4. GitHub Actions valida y publica el paquete con provenance.
+
+> Nota: el registro npm ya reporta `anastacio-beta@0.0.51`, asi que antes del siguiente release conviene subir la version local por encima de esa publicada.
 
 ## Contribucion
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anastacio-beta",
-  "version": "0.0.50",
+  "version": "0.0.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anastacio-beta",
-      "version": "0.0.50",
+      "version": "0.0.52",
       "license": "MIT",
       "dependencies": {
         "autoprefixer": "^10.4.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anastacio-beta",
-  "version": "0.0.50",
+  "version": "0.0.52",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -11,7 +11,9 @@
   "scripts": {
     "build": "tsc",
     "lint": "oxlint ./src",
-    "format": "biome format ./src --write"
+    "format": "biome format ./src --write",
+    "format:check": "biome check ./src",
+    "prepublishOnly": "npm run lint && npm run format:check && npm run build"
   },
   "keywords": [],
   "author": "Sergio Anastacio",

--- a/src/adapters/controllers/StaticFileController.ts
+++ b/src/adapters/controllers/StaticFileController.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { compressResponse } from "./CompressResponse.js";
 import { serveStaticAsset } from "../../infrastructure/webserver/serveStaticAsset.js";
+import { compressResponse } from "./CompressResponse.js";
 
 export const staticFileController = (rootFolder: string) => {
 	return async (req: IncomingMessage, res: ServerResponse) => {

--- a/src/adapters/controllers/StaticFileController.ts
+++ b/src/adapters/controllers/StaticFileController.ts
@@ -1,54 +1,26 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { ServeStaticFile } from "../../applications/use-cases/ServeStaticFiles.js";
-import { FileSystemRepository } from "../../infrastructure/Repository/FileSystemRepository.js";
-import path from "node:path";
 import { compressResponse } from "./CompressResponse.js";
-import fs from "node:fs/promises";
-
-const fileSystemRepository = new FileSystemRepository();
-const serveStaticFile = new ServeStaticFile(fileSystemRepository);
+import { serveStaticAsset } from "../../infrastructure/webserver/serveStaticAsset.js";
 
 export const staticFileController = (rootFolder: string) => {
 	return async (req: IncomingMessage, res: ServerResponse) => {
-		const parsedUrl = new URL(req.url || "", `http://${req.headers.host}`);
-		const filePath =
-			parsedUrl.pathname === "/" ? "/index.html" : parsedUrl.pathname;
-		const fullPath = path.join(rootFolder, filePath);
+		const parsedUrl = new URL(req.url || "/", `http://${req.headers.host}`);
 
 		try {
-			// Verificar si el archivo existe
-			await fs.access(fullPath);
-			const file = await serveStaticFile.execute(fullPath);
+			const asset = await serveStaticAsset(rootFolder, parsedUrl.pathname);
 			const acceptEncoding = req.headers["accept-encoding"] || "";
+
 			if (acceptEncoding.includes("gzip")) {
-				compressResponse(res, file.content, file.contentType);
-			} else {
-				res.writeHead(200, { "Content-Type": file.contentType });
-				res.end(file.content);
+				compressResponse(res, asset.content, asset.contentType);
+				return;
 			}
+
+			res.writeHead(200, { "Content-Type": asset.contentType });
+			res.end(asset.content);
 		} catch (error) {
-			if ((error as { code: string }).code === "ENOENT") {
-				// Si el archivo no existe, servir index.html
-				const indexPath = path.join(rootFolder, "index.html");
-				try {
-					const indexFile = await serveStaticFile.execute(indexPath);
-					const acceptEncoding = req.headers["accept-encoding"] || "";
-					if (acceptEncoding.includes("gzip")) {
-						compressResponse(res, indexFile.content, indexFile.contentType);
-					} else {
-						res.writeHead(200, { "Content-Type": indexFile.contentType });
-						res.end(indexFile.content);
-					}
-				} catch (indexError) {
-					console.error("Error:", indexError);
-					res.writeHead(404, { "Content-Type": "text/html" });
-					res.end("<h1>404 Not Found</h1>");
-				}
-			} else {
-				console.error("Error:", error);
-				res.writeHead(404, { "Content-Type": "text/html" });
-				res.end("<h1>404 Not Found</h1>");
-			}
+			console.error("Error serving static asset:", error);
+			res.writeHead(404, { "Content-Type": "text/html" });
+			res.end("<h1>404 Not Found</h1>");
 		}
 	};
 };

--- a/src/applications/use-cases/ServeStaticFiles.ts
+++ b/src/applications/use-cases/ServeStaticFiles.ts
@@ -1,7 +1,8 @@
 // src/applications/use-cases/ServeStaticFile.ts
-import type { IFileSystemRepository } from "../../infrastructure/IRepository/IFileSystemRepository.js";
-import { File } from "../../dominio/entities/File.js";
+
 import path from "node:path";
+import { File } from "../../dominio/entities/File.js";
+import type { IFileSystemRepository } from "../../infrastructure/IRepository/IFileSystemRepository.js";
 
 export class ServeStaticFile {
 	constructor(private fileSystemRepository: IFileSystemRepository) {}

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { Command } from "commander";
-import { startApp } from "../cli/start.js";
 import { buildApp } from "../cli/build.js";
 import { devApp } from "../cli/dev.js";
-import { inspectApp } from "../cli/inspect.js";
 import { doctorApp } from "../cli/doctor.js";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { inspectApp } from "../cli/inspect.js";
+import { startApp } from "../cli/start.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -1,7 +1,7 @@
-import { formatTime, Timer } from "../utils/Timer.js";
+import { createFrameworkContext } from "../core/index.js";
 import { EsbuildCompiler } from "../infrastructure/compiler/EsbuildCompiler.js";
 import { ServerMode } from "../infrastructure/webserver/ServerMode.js";
-import { createFrameworkContext } from "../core/index.js";
+import { formatTime, Timer } from "../utils/Timer.js";
 
 interface BuildAppOptions {
 	mode: string;

--- a/src/cli/dev.ts
+++ b/src/cli/dev.ts
@@ -1,6 +1,6 @@
+import { createFrameworkContext } from "../core/index.js";
 import { HttpServer } from "../infrastructure/webserver/HttpServer.js";
 import { ServerMode } from "../infrastructure/webserver/ServerMode.js";
-import { createFrameworkContext } from "../core/index.js";
 
 interface DevAppOptions {
 	port?: number;

--- a/src/cli/inspect.ts
+++ b/src/cli/inspect.ts
@@ -1,7 +1,4 @@
-import {
-	formatInspectionReport,
-	inspectProject,
-} from "../inspector/index.js";
+import { formatInspectionReport, inspectProject } from "../inspector/index.js";
 
 interface InspectAppOptions {
 	root?: string;

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -1,6 +1,6 @@
+import { createFrameworkContext } from "../core/index.js";
 import { HttpServer } from "../infrastructure/webserver/HttpServer.js";
 import { ServerMode } from "../infrastructure/webserver/ServerMode.js";
-import { createFrameworkContext } from "../core/index.js";
 
 interface startAppOptions {
 	port?: number;

--- a/src/core/config/loadAnastacioConfig.ts
+++ b/src/core/config/loadAnastacioConfig.ts
@@ -1,6 +1,6 @@
-import { build } from "esbuild";
 import { existsSync, readFileSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
+import { build } from "esbuild";
 import type {
 	AnastacioConfig,
 	AnastacioUserConfig,
@@ -121,7 +121,10 @@ function resolveAnastacioConfig(
 	userConfig: AnastacioUserConfig,
 ): AnastacioConfig {
 	const srcDir = resolveProjectPath(rootDir, userConfig.paths?.srcDir ?? "src");
-	const outDir = resolveProjectPath(rootDir, userConfig.paths?.outDir ?? "dist");
+	const outDir = resolveProjectPath(
+		rootDir,
+		userConfig.paths?.outDir ?? "dist",
+	);
 	const appDir = resolveProjectPath(
 		rootDir,
 		userConfig.paths?.appDir ?? join(srcDir, "app"),
@@ -160,9 +163,7 @@ function resolveAnastacioConfig(
 }
 
 function resolveProjectPath(projectRoot: string, targetPath: string): string {
-	return isAbsolute(targetPath)
-		? targetPath
-		: resolve(projectRoot, targetPath);
+	return isAbsolute(targetPath) ? targetPath : resolve(projectRoot, targetPath);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -1,6 +1,9 @@
-import { loadAnastacioConfig } from "./config/index.js";
 import { resolveRoutes } from "../router/index.js";
-import type { AnastacioConfig, RouteDefinition } from "../shared/contracts/index.js";
+import type {
+	AnastacioConfig,
+	RouteDefinition,
+} from "../shared/contracts/index.js";
+import { loadAnastacioConfig } from "./config/index.js";
 
 export interface AnastacioFrameworkContext {
 	rootDir: string;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,6 +1,6 @@
-export type { AnastacioFrameworkContext } from "./context.js";
-export { createFrameworkContext } from "./context.js";
 export {
 	findAnastacioConfigPath,
 	loadAnastacioConfig,
 } from "./config/index.js";
+export type { AnastacioFrameworkContext } from "./context.js";
+export { createFrameworkContext } from "./context.js";

--- a/src/doctor/diagnoseProject.ts
+++ b/src/doctor/diagnoseProject.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { join, relative, sep } from "node:path";
 import { createFrameworkContext, findAnastacioConfigPath } from "../core/index.js";
 import { writeRoutesManifest } from "../router/index.js";
@@ -8,6 +8,22 @@ import type {
 	DiagnosticReport,
 	RouteDefinition,
 } from "../shared/contracts/index.js";
+
+const ROOT_LAYOUT_FILE_NAMES = ["layout.tsx", "layout.jsx"];
+const PAGE_FILE_NAMES = ["page.tsx", "page.jsx"];
+const LOADING_FILE_NAMES = ["loading.tsx", "loading.jsx"];
+const ERROR_FILE_NAMES = [
+	"error.tsx",
+	"error.jsx",
+	"errorPage.tsx",
+	"errorPage.jsx",
+];
+const NOT_FOUND_FILE_NAMES = [
+	"notfound.tsx",
+	"notfound.jsx",
+	"not-found.tsx",
+	"not-found.jsx",
+];
 
 export interface DoctorReport {
 	rootDir: string;
@@ -166,6 +182,25 @@ function collectDiagnostics(
 		});
 	}
 
+	collectDuplicateRouteDiagnostics(routes, diagnostics);
+
+	if (existsSync(appDir)) {
+		collectDirectoryShapeDiagnostics(config, diagnostics);
+		collectRouteMetadataDiagnostics(config, routes, diagnostics);
+	}
+
+	return diagnostics.sort(
+		(left, right) =>
+			severityRank(left.severity) - severityRank(right.severity) ||
+			left.code.localeCompare(right.code) ||
+			(left.file ?? "").localeCompare(right.file ?? ""),
+	);
+}
+
+function collectDuplicateRouteDiagnostics(
+	routes: RouteDefinition[],
+	diagnostics: Diagnostic[],
+): void {
 	const routeCounts = new Map<string, number>();
 	for (const route of routes) {
 		routeCounts.set(route.path, (routeCounts.get(route.path) ?? 0) + 1);
@@ -192,9 +227,7 @@ function collectDiagnostics(
 	}
 
 	for (const [signature, signatureRoutes] of routesBySignature.entries()) {
-		const distinctPaths = new Set(
-			signatureRoutes.map((route) => route.path),
-		);
+		const distinctPaths = new Set(signatureRoutes.map((route) => route.path));
 		if (distinctPaths.size < 2) {
 			continue;
 		}
@@ -212,12 +245,157 @@ function collectDiagnostics(
 				"Rename or reorganize dynamic segments so each semantic route shape is unique.",
 		});
 	}
+}
 
-	return diagnostics.sort(
-		(left, right) =>
-			severityRank(left.severity) - severityRank(right.severity) ||
-			left.code.localeCompare(right.code),
-	);
+function collectDirectoryShapeDiagnostics(
+	config: AnastacioConfig,
+	diagnostics: Diagnostic[],
+): void {
+	walkAppDirectory(config.paths.appDir, (directory) => {
+		const directoryEntries = readdirSync(directory, { withFileTypes: true });
+		const fileNames = new Set(
+			directoryEntries.filter((entry) => entry.isFile()).map((entry) => entry.name),
+		);
+		const relativeDirectory = toProjectRelative(config.rootDir, directory);
+		const pageCount = countKnownFiles(fileNames, PAGE_FILE_NAMES);
+		const layoutCount = countKnownFiles(fileNames, ROOT_LAYOUT_FILE_NAMES);
+		const loadingCount = countKnownFiles(fileNames, LOADING_FILE_NAMES);
+		const errorCount = countKnownFiles(fileNames, ERROR_FILE_NAMES);
+		const notFoundCount = countKnownFiles(fileNames, NOT_FOUND_FILE_NAMES);
+
+		if (pageCount > 1) {
+			diagnostics.push({
+				code: "MULTIPLE_PAGE_FILES",
+				severity: "error",
+				message: "More than one page file was found in the same route directory.",
+				file: relativeDirectory,
+				suggestion:
+					"Keep a single page.tsx/page.jsx per route directory.",
+			});
+		}
+
+		if (layoutCount > 1) {
+			diagnostics.push({
+				code: "MULTIPLE_LAYOUT_FILES",
+				severity: "error",
+				message: "More than one layout file was found in the same directory.",
+				file: relativeDirectory,
+				suggestion:
+					"Keep a single layout.tsx/layout.jsx per directory.",
+			});
+		}
+
+		if (loadingCount > 1) {
+			diagnostics.push({
+				code: "MULTIPLE_LOADING_FILES",
+				severity: "error",
+				message: "More than one loading file was found in the same directory.",
+				file: relativeDirectory,
+				suggestion:
+					"Keep a single loading.tsx/loading.jsx per directory.",
+			});
+		}
+
+		if (errorCount > 1) {
+			diagnostics.push({
+				code: "MULTIPLE_ERROR_FILES",
+				severity: "error",
+				message: "More than one error boundary file was found in the same directory.",
+				file: relativeDirectory,
+				suggestion:
+					"Keep a single error.tsx/error.jsx or errorPage.tsx/errorPage.jsx per directory.",
+			});
+		}
+
+		if (notFoundCount > 1) {
+			diagnostics.push({
+				code: "MULTIPLE_NOT_FOUND_FILES",
+				severity: "error",
+				message: "More than one not-found file was found in the same directory.",
+				file: relativeDirectory,
+				suggestion:
+					"Keep a single notfound.tsx/notfound.jsx or not-found.tsx/not-found.jsx per directory.",
+			});
+		}
+
+		if (isDynamicDirectory(directory) && pageCount === 0 && !hasChildDirectories(directory)) {
+			diagnostics.push({
+				code: "EMPTY_DYNAMIC_ROUTE_DIRECTORY",
+				severity: "warning",
+				message:
+					"A dynamic route directory exists without a page file or nested child routes.",
+				file: relativeDirectory,
+				suggestion:
+					"Add a page.tsx file or nested route directories, or remove the unused dynamic segment.",
+			});
+		}
+
+		if (loadingCount > 0 && pageCount === 0 && !hasChildDirectories(directory)) {
+			diagnostics.push({
+				code: "ORPHAN_LOADING_FILE",
+				severity: "warning",
+				message:
+					"A loading file exists in a directory without a page file or nested child routes.",
+				file: relativeDirectory,
+				suggestion:
+					"Add a page.tsx or child route, or remove the unused loading file.",
+			});
+		}
+
+		if (errorCount > 0 && pageCount === 0 && !hasChildDirectories(directory)) {
+			diagnostics.push({
+				code: "ORPHAN_ERROR_FILE",
+				severity: "warning",
+				message:
+					"An error boundary file exists in a directory without a page file or nested child routes.",
+				file: relativeDirectory,
+				suggestion:
+					"Add a page.tsx or child route, or remove the unused error file.",
+			});
+		}
+
+		if (notFoundCount > 0 && pageCount === 0 && !hasChildDirectories(directory)) {
+			diagnostics.push({
+				code: "ORPHAN_NOT_FOUND_FILE",
+				severity: "warning",
+				message:
+					"A not-found file exists in a directory without a page file or nested child routes.",
+				file: relativeDirectory,
+				suggestion:
+					"Add a page.tsx or child route, or remove the unused not-found file.",
+			});
+		}
+	});
+}
+
+function collectRouteMetadataDiagnostics(
+	config: AnastacioConfig,
+	routes: RouteDefinition[],
+	diagnostics: Diagnostic[],
+): void {
+	for (const route of routes) {
+		const routeDirectory = join(config.rootDir, route.file, "..");
+		if (!route.layout) {
+			diagnostics.push({
+				code: "ROUTE_WITHOUT_LAYOUT",
+				severity: "info",
+				message: `Route "${route.path}" does not resolve to any layout file.`,
+				file: route.file,
+				suggestion:
+					"Add a nearby layout.tsx or a root src/app/layout.tsx if the route should share application chrome.",
+			});
+		}
+
+		if (route.hasLoading === false && hasKnownFile(routeDirectory, LOADING_FILE_NAMES)) {
+			diagnostics.push({
+				code: "LOADING_METADATA_MISMATCH",
+				severity: "warning",
+				message: `Route "${route.path}" appears to have a loading file that was not reflected in route metadata.`,
+				file: route.file,
+				suggestion: "Review route resolution for loading.tsx inheritance and metadata propagation.",
+			});
+		}
+	}
 }
 
 function writeDiagnosticsReport(
@@ -248,7 +426,22 @@ function severityRank(severity: Diagnostic["severity"]): number {
 	}
 }
 
-const ROOT_LAYOUT_FILE_NAMES = ["layout.tsx", "layout.jsx"];
+function walkAppDirectory(
+	directory: string,
+	visitor: (directory: string) => void,
+): void {
+	visitor(directory);
+	const entries = readdirSync(directory, { withFileTypes: true });
+	for (const entry of entries) {
+		if (entry.isDirectory()) {
+			walkAppDirectory(join(directory, entry.name), visitor);
+		}
+	}
+}
+
+function countKnownFiles(fileNames: Set<string>, candidates: string[]): number {
+	return candidates.filter((fileName) => fileNames.has(fileName)).length;
+}
 
 function hasKnownFile(directory: string, fileNames: string[]): boolean {
 	for (const fileName of fileNames) {
@@ -258,6 +451,17 @@ function hasKnownFile(directory: string, fileNames: string[]): boolean {
 	}
 
 	return false;
+}
+
+function hasChildDirectories(directory: string): boolean {
+	return readdirSync(directory, { withFileTypes: true }).some((entry) =>
+		entry.isDirectory(),
+	);
+}
+
+function isDynamicDirectory(directory: string): boolean {
+	const baseName = directory.split(/[\\/]/).pop() ?? "";
+	return baseName.startsWith("[") && baseName.endsWith("]");
 }
 
 function toRouteSignature(routePath: string): string {

--- a/src/doctor/diagnoseProject.ts
+++ b/src/doctor/diagnoseProject.ts
@@ -1,6 +1,9 @@
 import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { join, relative, sep } from "node:path";
-import { createFrameworkContext, findAnastacioConfigPath } from "../core/index.js";
+import {
+	createFrameworkContext,
+	findAnastacioConfigPath,
+} from "../core/index.js";
 import { writeRoutesManifest } from "../router/index.js";
 import type {
 	AnastacioConfig,
@@ -254,7 +257,9 @@ function collectDirectoryShapeDiagnostics(
 	walkAppDirectory(config.paths.appDir, (directory) => {
 		const directoryEntries = readdirSync(directory, { withFileTypes: true });
 		const fileNames = new Set(
-			directoryEntries.filter((entry) => entry.isFile()).map((entry) => entry.name),
+			directoryEntries
+				.filter((entry) => entry.isFile())
+				.map((entry) => entry.name),
 		);
 		const relativeDirectory = toProjectRelative(config.rootDir, directory);
 		const pageCount = countKnownFiles(fileNames, PAGE_FILE_NAMES);
@@ -267,10 +272,10 @@ function collectDirectoryShapeDiagnostics(
 			diagnostics.push({
 				code: "MULTIPLE_PAGE_FILES",
 				severity: "error",
-				message: "More than one page file was found in the same route directory.",
+				message:
+					"More than one page file was found in the same route directory.",
 				file: relativeDirectory,
-				suggestion:
-					"Keep a single page.tsx/page.jsx per route directory.",
+				suggestion: "Keep a single page.tsx/page.jsx per route directory.",
 			});
 		}
 
@@ -280,8 +285,7 @@ function collectDirectoryShapeDiagnostics(
 				severity: "error",
 				message: "More than one layout file was found in the same directory.",
 				file: relativeDirectory,
-				suggestion:
-					"Keep a single layout.tsx/layout.jsx per directory.",
+				suggestion: "Keep a single layout.tsx/layout.jsx per directory.",
 			});
 		}
 
@@ -291,8 +295,7 @@ function collectDirectoryShapeDiagnostics(
 				severity: "error",
 				message: "More than one loading file was found in the same directory.",
 				file: relativeDirectory,
-				suggestion:
-					"Keep a single loading.tsx/loading.jsx per directory.",
+				suggestion: "Keep a single loading.tsx/loading.jsx per directory.",
 			});
 		}
 
@@ -300,7 +303,8 @@ function collectDirectoryShapeDiagnostics(
 			diagnostics.push({
 				code: "MULTIPLE_ERROR_FILES",
 				severity: "error",
-				message: "More than one error boundary file was found in the same directory.",
+				message:
+					"More than one error boundary file was found in the same directory.",
 				file: relativeDirectory,
 				suggestion:
 					"Keep a single error.tsx/error.jsx or errorPage.tsx/errorPage.jsx per directory.",
@@ -311,14 +315,19 @@ function collectDirectoryShapeDiagnostics(
 			diagnostics.push({
 				code: "MULTIPLE_NOT_FOUND_FILES",
 				severity: "error",
-				message: "More than one not-found file was found in the same directory.",
+				message:
+					"More than one not-found file was found in the same directory.",
 				file: relativeDirectory,
 				suggestion:
 					"Keep a single notfound.tsx/notfound.jsx or not-found.tsx/not-found.jsx per directory.",
 			});
 		}
 
-		if (isDynamicDirectory(directory) && pageCount === 0 && !hasChildDirectories(directory)) {
+		if (
+			isDynamicDirectory(directory) &&
+			pageCount === 0 &&
+			!hasChildDirectories(directory)
+		) {
 			diagnostics.push({
 				code: "EMPTY_DYNAMIC_ROUTE_DIRECTORY",
 				severity: "warning",
@@ -330,7 +339,11 @@ function collectDirectoryShapeDiagnostics(
 			});
 		}
 
-		if (loadingCount > 0 && pageCount === 0 && !hasChildDirectories(directory)) {
+		if (
+			loadingCount > 0 &&
+			pageCount === 0 &&
+			!hasChildDirectories(directory)
+		) {
 			diagnostics.push({
 				code: "ORPHAN_LOADING_FILE",
 				severity: "warning",
@@ -354,7 +367,11 @@ function collectDirectoryShapeDiagnostics(
 			});
 		}
 
-		if (notFoundCount > 0 && pageCount === 0 && !hasChildDirectories(directory)) {
+		if (
+			notFoundCount > 0 &&
+			pageCount === 0 &&
+			!hasChildDirectories(directory)
+		) {
 			diagnostics.push({
 				code: "ORPHAN_NOT_FOUND_FILE",
 				severity: "warning",
@@ -386,13 +403,17 @@ function collectRouteMetadataDiagnostics(
 			});
 		}
 
-		if (route.hasLoading === false && hasKnownFile(routeDirectory, LOADING_FILE_NAMES)) {
+		if (
+			route.hasLoading === false &&
+			hasKnownFile(routeDirectory, LOADING_FILE_NAMES)
+		) {
 			diagnostics.push({
 				code: "LOADING_METADATA_MISMATCH",
 				severity: "warning",
 				message: `Route "${route.path}" appears to have a loading file that was not reflected in route metadata.`,
 				file: route.file,
-				suggestion: "Review route resolution for loading.tsx inheritance and metadata propagation.",
+				suggestion:
+					"Review route resolution for loading.tsx inheritance and metadata propagation.",
 			});
 		}
 	}

--- a/src/infrastructure/Repository/FileSystemRepository.ts
+++ b/src/infrastructure/Repository/FileSystemRepository.ts
@@ -1,7 +1,8 @@
 // src/Infrastructure/Repository/FileSystemRepository.ts
-import type { IFileSystemRepository } from "../IRepository/IFileSystemRepository.js";
+
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { IFileSystemRepository } from "../IRepository/IFileSystemRepository.js";
 
 export class FileSystemRepository implements IFileSystemRepository {
 	async readFile(filePath: string): Promise<Buffer> {

--- a/src/infrastructure/Repository/ServerRepository.ts
+++ b/src/infrastructure/Repository/ServerRepository.ts
@@ -1,6 +1,7 @@
 // src/Infrastructure/Repository/ServerRepository.ts
-import type { IServerRepository } from "../IRepository/IServerRepository.js";
+
 import type { Server } from "../../dominio/entities/Server.js";
+import type { IServerRepository } from "../IRepository/IServerRepository.js";
 
 export class ServerRepository implements IServerRepository {
 	private servers: Server[] = [];

--- a/src/infrastructure/compiler/EsbuildCompiler.ts
+++ b/src/infrastructure/compiler/EsbuildCompiler.ts
@@ -1,18 +1,19 @@
 // src/infrastructure/compiler/EsbuildCompiler.ts
-import type esbuild from "esbuild";
+
 import { existsSync, watch } from "node:fs";
 import colors from "colors";
+import type esbuild from "esbuild";
 import { type BuildOptions, context } from "esbuild";
-import { ServerMode } from "../webserver/ServerMode.js";
-import type { IEsbuildCompiler } from "./IEsbuildCompiler.js";
-import type { HotReloadServer } from "../websocket/HotReloadServer.js";
-import { formatTime, Timer } from "../../utils/Timer.js";
-import { DevPlugin } from "../../plugins/DevEntry.js";
-import { ProdPlugin } from "../../plugins/ProdEntry.js";
-import { MinifyImagesPlugin } from "../../plugins/MinifyImages.js";
 import { RouterPlugin } from "../../plugins/AppRouter.js";
+import { DevPlugin } from "../../plugins/DevEntry.js";
+import { MinifyImagesPlugin } from "../../plugins/MinifyImages.js";
 import { PostCSSPlugin } from "../../plugins/PostCSSPlugin.js";
+import { ProdPlugin } from "../../plugins/ProdEntry.js";
 import type { AnastacioConfig } from "../../shared/contracts/index.js";
+import { formatTime, Timer } from "../../utils/Timer.js";
+import { ServerMode } from "../webserver/ServerMode.js";
+import type { HotReloadServer } from "../websocket/HotReloadServer.js";
+import type { IEsbuildCompiler } from "./IEsbuildCompiler.js";
 
 export class EsbuildCompiler implements IEsbuildCompiler {
 	public config: AnastacioConfig;
@@ -107,7 +108,7 @@ export class EsbuildCompiler implements IEsbuildCompiler {
 		watch(
 			this.config.paths.srcDir,
 			{ recursive: true, encoding: "utf8" },
-			async (eventType: string, filename: string | null) => {
+			async (_eventType: string, filename: string | null) => {
 				if (filename) {
 					if (filename.replace(/\\/g, "/").endsWith("AppRouter.tsx")) {
 						return;

--- a/src/infrastructure/compiler/EsbuildCompiler.ts
+++ b/src/infrastructure/compiler/EsbuildCompiler.ts
@@ -36,6 +36,7 @@ export class EsbuildCompiler implements IEsbuildCompiler {
 
 	async compile() {
 		this.validateInputs();
+		await this.dispose();
 		const plugins = this.getPlugins();
 		const buildOptions = this.getBuildOptions(plugins);
 
@@ -132,6 +133,13 @@ export class EsbuildCompiler implements IEsbuildCompiler {
 	}
 
 	private validateInputs(): void {
+		if (!existsSync(this.config.paths.srcDir)) {
+			throw new Error(
+				`Source directory not found: ${this.config.paths.srcDir}. ` +
+					"Create the directory or configure paths.srcDir in anastacio.config.ts.",
+			);
+		}
+
 		if (!existsSync(this.config.paths.entryFile)) {
 			throw new Error(
 				`Entry file not found: ${this.config.paths.entryFile}. ` +
@@ -143,12 +151,18 @@ export class EsbuildCompiler implements IEsbuildCompiler {
 	// Método para compilar el código
 	// ! No existe el método build en la interfaz IEsbuildCompiler
 	// ! Por lo que usamos el método rebuild
+	async dispose(): Promise<void> {
+		if (this.ctx) {
+			await this.ctx.dispose();
+			this.ctx = null;
+		}
+	}
+
 	private async runBuild() {
 		await Timer("Build", async () => {
 			if (this.ctx) {
 				await this.ctx.rebuild();
-				await this.ctx.dispose();
-				this.ctx = null;
+				await this.dispose();
 			}
 		});
 		console.log("Build completed successfully.");

--- a/src/infrastructure/compiler/IEsbuildCompiler.ts
+++ b/src/infrastructure/compiler/IEsbuildCompiler.ts
@@ -9,4 +9,5 @@ export interface IEsbuildCompiler {
 	outfile: string;
 	mode: ServerMode;
 	compile(): Promise<void>;
+	dispose(): Promise<void>;
 }

--- a/src/infrastructure/webserver/HttpServer.ts
+++ b/src/infrastructure/webserver/HttpServer.ts
@@ -1,12 +1,12 @@
 // src/Infrastructure/webserver/HttpServer.ts
 import http from "node:http";
 import { staticFileController } from "../../adapters/controllers/StaticFileController.js";
-import { HotReloadServer } from "../websocket/HotReloadServer.js";
+import type { AnastacioConfig } from "../../shared/contracts/index.js";
+import { FindFreePort } from "../../utils/FindFreePort.js";
 import { EsbuildCompiler } from "../compiler/EsbuildCompiler.js";
+import { HotReloadServer } from "../websocket/HotReloadServer.js";
 import type { IHttpServer } from "./IHttpServer.js";
 import { ServerMode } from "./ServerMode.js";
-import { FindFreePort } from "../../utils/FindFreePort.js";
-import type { AnastacioConfig } from "../../shared/contracts/index.js";
 
 interface HttpServerOverrides {
 	host?: string;
@@ -33,9 +33,7 @@ export class HttpServer implements IHttpServer {
 		this.port = overrides.port ?? config.dev.port;
 		this.wsPort = overrides.wsPort ?? config.dev.wsPort;
 		this.validateRuntimeConfig();
-		this.server = http.createServer(
-			staticFileController(config.paths.outDir),
-		);
+		this.server = http.createServer(staticFileController(config.paths.outDir));
 		this.hotReloadServer =
 			mode === ServerMode.Development
 				? new HotReloadServer(this.wsPort)

--- a/src/infrastructure/webserver/HttpServer.ts
+++ b/src/infrastructure/webserver/HttpServer.ts
@@ -4,7 +4,7 @@ import { staticFileController } from "../../adapters/controllers/StaticFileContr
 import { HotReloadServer } from "../websocket/HotReloadServer.js";
 import { EsbuildCompiler } from "../compiler/EsbuildCompiler.js";
 import type { IHttpServer } from "./IHttpServer.js";
-import type { ServerMode } from "./ServerMode.js";
+import { ServerMode } from "./ServerMode.js";
 import { FindFreePort } from "../../utils/FindFreePort.js";
 import type { AnastacioConfig } from "../../shared/contracts/index.js";
 
@@ -19,7 +19,7 @@ export class HttpServer implements IHttpServer {
 	private hotReloadServer?: HotReloadServer;
 	private compiler: EsbuildCompiler;
 	private freePort = 0;
-	private freeWsPort: number;
+	private freeWsPort?: number;
 	public hostname: string;
 	public port: number;
 	public wsPort: number;
@@ -32,32 +32,50 @@ export class HttpServer implements IHttpServer {
 		this.hostname = overrides.host ?? config.dev.host;
 		this.port = overrides.port ?? config.dev.port;
 		this.wsPort = overrides.wsPort ?? config.dev.wsPort;
-		this.freeWsPort = this.wsPort;
+		this.validateRuntimeConfig();
 		this.server = http.createServer(
 			staticFileController(config.paths.outDir),
 		);
-		this.hotReloadServer = new HotReloadServer(this.wsPort);
+		this.hotReloadServer =
+			mode === ServerMode.Development
+				? new HotReloadServer(this.wsPort)
+				: undefined;
 		this.compiler = new EsbuildCompiler(config, mode, this.hotReloadServer);
 	}
 
 	async init() {
-		//Para ambos casos se requiere el servidor http
 		this.freePort = await FindFreePort(this.port);
-		// Compilar los archivos de React
-		await this.compiler.compile(); //Compilamos el codigo
-		// Iniciar el servidor HTTP
-		this.server.listen(this.freePort, this.hostname, () => {
-			console.log(
-				`Server running at http://${this.hostname}:${this.freePort}/`,
-			);
-			console.log(
-				`WebSocket server running at ws://${this.hostname}:${this.freeWsPort}/`,
-			);
+		if (this.hotReloadServer) {
+			this.freeWsPort = await FindFreePort(this.wsPort);
+			if (this.freeWsPort !== this.wsPort) {
+				this.hotReloadServer.close();
+				this.hotReloadServer = new HotReloadServer(this.freeWsPort);
+				this.compiler = new EsbuildCompiler(
+					this.config,
+					this.mode,
+					this.hotReloadServer,
+				);
+			}
+		}
+
+		await this.compiler.compile();
+		await new Promise<void>((resolve) => {
+			this.server.listen(this.freePort, this.hostname, () => {
+				console.log(
+					`Server running at http://${this.hostname}:${this.freePort}/`,
+				);
+				if (this.hotReloadServer && this.freeWsPort) {
+					console.log(
+						`WebSocket server running at ws://${this.hostname}:${this.freeWsPort}/`,
+					);
+				}
+				resolve();
+			});
 		});
 	}
 
-	start() {
-		void this.init();
+	start(): Promise<void> {
+		return this.init();
 	}
 
 	notifyClients() {
@@ -68,16 +86,36 @@ export class HttpServer implements IHttpServer {
 
 	async handleSessionStop(signal: NodeJS.Signals): Promise<void> {
 		console.log(`Received ${signal}. Closing servers...`);
-		this.closeServers();
+		await this.closeServers();
 		process.exit(0);
 	}
 
-	public closeServers(): void {
-		if (this.server) {
+	private validateRuntimeConfig(): void {
+		for (const [label, value] of [
+			["port", this.port],
+			["wsPort", this.wsPort],
+		] as const) {
+			if (!Number.isInteger(value) || value < 1 || value > 65535) {
+				throw new Error(
+					`Invalid ${label}: ${value}. Use a port between 1 and 65535 in anastacio.config.ts or CLI options.`,
+				);
+			}
+		}
+	}
+
+	public async closeServers(): Promise<void> {
+		await this.compiler.dispose();
+		await new Promise<void>((resolve) => {
+			if (!this.server.listening) {
+				resolve();
+				return;
+			}
+
 			this.server.close(() => {
 				console.log("HTTP server closed");
+				resolve();
 			});
-		}
+		});
 		if (this.hotReloadServer) {
 			this.hotReloadServer.close();
 		}

--- a/src/infrastructure/webserver/IHttpServer.ts
+++ b/src/infrastructure/webserver/IHttpServer.ts
@@ -6,8 +6,8 @@ export interface IHttpServer {
 	port: number;
 	mode: ServerMode;
 	init(): Promise<void>;
-	start(): void;
+	start(): Promise<void>;
 	notifyClients(): void;
-	closeServers(): void;
+	closeServers(): Promise<void>;
 	handleSessionStop(signal: string): Promise<void>;
 }

--- a/src/infrastructure/webserver/serveStaticAsset.ts
+++ b/src/infrastructure/webserver/serveStaticAsset.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export interface StaticAsset {
+	filePath: string;
+	content: Buffer;
+	contentType: string;
+}
+
+export async function serveStaticAsset(
+	rootFolder: string,
+	requestPath: string,
+): Promise<StaticAsset> {
+	const normalizedPath = requestPath === "/" ? "/index.html" : requestPath;
+	const resolvedPath = path.join(rootFolder, normalizedPath);
+
+	try {
+		return await readStaticAsset(resolvedPath);
+	} catch (error) {
+		if ((error as { code?: string }).code !== "ENOENT") {
+			throw error;
+		}
+
+		return readStaticAsset(path.join(rootFolder, "index.html"));
+	}
+}
+
+async function readStaticAsset(filePath: string): Promise<StaticAsset> {
+	const content = await fs.readFile(filePath);
+	return {
+		filePath,
+		content,
+		contentType: getContentType(filePath),
+	};
+}
+
+function getContentType(filePath: string): string {
+	switch (path.extname(filePath).toLowerCase()) {
+		case ".html":
+			return "text/html";
+		case ".js":
+			return "text/javascript";
+		case ".css":
+			return "text/css";
+		case ".png":
+			return "image/png";
+		case ".jpg":
+		case ".jpeg":
+			return "image/jpeg";
+		case ".gif":
+			return "image/gif";
+		case ".svg":
+			return "image/svg+xml";
+		case ".ico":
+			return "image/x-icon";
+		case ".webp":
+			return "image/webp";
+		case ".avif":
+			return "image/avif";
+		case ".json":
+			return "application/json";
+		default:
+			return "application/octet-stream";
+	}
+}

--- a/src/infrastructure/websocket/HotReloadServer.ts
+++ b/src/infrastructure/websocket/HotReloadServer.ts
@@ -3,11 +3,9 @@ import { WebSocketServer } from "ws";
 
 export class HotReloadServer {
 	private wss: WebSocketServer;
-	private currentPort: number;
 
 	// Crear un servidor WebSocket en el puerto especificado
 	constructor(port: number) {
-		this.currentPort = port;
 		this.wss = new WebSocketServer({ port });
 		this.wss.on("connection", (_ws) => {
 			console.log(`Client connected for hot-reload on port ${port}`);
@@ -33,7 +31,6 @@ export class HotReloadServer {
 	// Cambiar el puerto del servidor WebSocket
 	public async changePort(newPort: number) {
 		this.close();
-		this.currentPort = newPort;
 		this.wss = new WebSocketServer({ port: newPort });
 		this.wss.on("connection", (_ws) => {
 			console.log(`Client connected for hot-reload on port ${newPort}`);

--- a/src/inspector/inspectProject.ts
+++ b/src/inspector/inspectProject.ts
@@ -15,6 +15,15 @@ export interface InspectionReport {
 		outDir: string;
 		internalDir: string;
 	};
+	summary: {
+		routeCount: number;
+		dynamicRouteCount: number;
+		layoutCount: number;
+		routesWithLoading: number;
+		routesWithErrorBoundary: number;
+		routesWithNotFound: number;
+	};
+	conventions: string[];
 	artifacts: {
 		routesManifest: string;
 		projectContext: string;
@@ -29,6 +38,8 @@ export async function inspectProject(
 	const { config, routes } = framework;
 	const routesManifestPath = writeRoutesManifest(config, routes);
 	const projectContextPath = writeProjectContext(config, routes);
+	const summary = buildSummary(routes);
+	const conventions = buildConventions(config);
 
 	return {
 		rootDir: config.rootDir,
@@ -38,6 +49,8 @@ export async function inspectProject(
 			outDir: toProjectRelative(config.rootDir, config.paths.outDir),
 			internalDir: toProjectRelative(config.rootDir, config.paths.internalDir),
 		},
+		summary,
+		conventions,
 		artifacts: {
 			routesManifest: toProjectRelative(config.rootDir, routesManifestPath),
 			projectContext: toProjectRelative(config.rootDir, projectContextPath),
@@ -53,7 +66,12 @@ export function formatInspectionReport(report: InspectionReport): string {
 		`appDir: ${report.paths.appDir}`,
 		`entryFile: ${report.paths.entryFile}`,
 		`outDir: ${report.paths.outDir}`,
-		`routes: ${report.routes.length}`,
+		`routes: ${report.summary.routeCount}`,
+		`dynamicRoutes: ${report.summary.dynamicRouteCount}`,
+		`layouts: ${report.summary.layoutCount}`,
+		`routesWithLoading: ${report.summary.routesWithLoading}`,
+		`routesWithErrorBoundary: ${report.summary.routesWithErrorBoundary}`,
+		`routesWithNotFound: ${report.summary.routesWithNotFound}`,
 		`routes.manifest.json: ${report.artifacts.routesManifest}`,
 		`project-context.md: ${report.artifacts.projectContext}`,
 	];
@@ -64,10 +82,26 @@ export function formatInspectionReport(report: InspectionReport): string {
 	}
 
 	lines.push("");
+	lines.push("Routes:");
 	for (const route of report.routes) {
-		lines.push(
-			`${route.path} -> ${route.file}${route.layout ? ` [layout: ${route.layout}]` : ""}`,
-		);
+		const flags = [
+			route.layout ? `layout=${route.layout}` : "no-layout",
+			route.dynamicParams?.length
+				? `params=${route.dynamicParams.join(",")}`
+				: null,
+			route.hasLoading ? "loading" : null,
+			route.hasErrorBoundary ? "error" : null,
+			route.hasNotFound ? "notFound" : null,
+		]
+			.filter(Boolean)
+			.join(" | ");
+		lines.push(`- ${route.path} -> ${route.file}${flags ? ` [${flags}]` : ""}`);
+	}
+
+	lines.push("");
+	lines.push("Conventions:");
+	for (const convention of report.conventions) {
+		lines.push(`- ${convention}`);
 	}
 
 	return lines.join("\n");
@@ -80,6 +114,8 @@ function writeProjectContext(
 	mkdirSync(config.paths.internalDir, { recursive: true });
 
 	const outputPath = join(config.paths.internalDir, "project-context.md");
+	const summary = buildSummary(routes);
+	const conventions = buildConventions(config);
 	const lines = [
 		"# Anastacio Project Context",
 		"",
@@ -89,6 +125,16 @@ function writeProjectContext(
 		`- appDir: \`${toProjectRelative(config.rootDir, config.paths.appDir)}\``,
 		`- entryFile: \`${toProjectRelative(config.rootDir, config.paths.entryFile)}\``,
 		`- outDir: \`${toProjectRelative(config.rootDir, config.paths.outDir)}\``,
+		`- internalDir: \`${toProjectRelative(config.rootDir, config.paths.internalDir)}\``,
+		"",
+		"## Summary",
+		"",
+		`- routes: **${summary.routeCount}**`,
+		`- dynamic routes: **${summary.dynamicRouteCount}**`,
+		`- unique layouts: **${summary.layoutCount}**`,
+		`- routes with loading: **${summary.routesWithLoading}**`,
+		`- routes with error boundary: **${summary.routesWithErrorBoundary}**`,
+		`- routes with not-found handling: **${summary.routesWithNotFound}**`,
 		"",
 		"## Routes",
 		"",
@@ -105,6 +151,9 @@ function writeProjectContext(
 				...(route.dynamicParams?.length
 					? [`params: \`${route.dynamicParams.join(", ")}\``]
 					: []),
+				...(route.hasLoading ? ["loading: `yes`"] : []),
+				...(route.hasErrorBoundary ? ["errorBoundary: `yes`"] : []),
+				...(route.hasNotFound ? ["notFound: `yes`"] : []),
 			];
 			lines.push(`- ${details.join(" | ")}`);
 		}
@@ -113,15 +162,72 @@ function writeProjectContext(
 	lines.push("");
 	lines.push("## Conventions");
 	lines.push("");
-	lines.push(
-		`- File-based routing under \`${toProjectRelative(config.rootDir, config.paths.appDir)}\` by default.`,
-	);
-	lines.push("- Layout inheritance uses the nearest `layout.tsx`.");
-	lines.push("- Route manifests are written to `.anastacio/`.");
+	for (const convention of conventions) {
+		lines.push(`- ${convention}`);
+	}
+
+	lines.push("");
+	lines.push("## Observations");
+	lines.push("");
+	if (summary.routeCount === 0) {
+		lines.push(
+			"- The project currently exposes no routes. Add `page.tsx` files under the app directory to make the application structure visible.",
+		);
+	} else {
+		if (summary.dynamicRouteCount > 0) {
+			lines.push(
+				`- Dynamic routing is active through ${summary.dynamicRouteCount} route(s), which is useful for inspect/doctor tooling and future agent-oriented manifests.`,
+			);
+		}
+		if (summary.layoutCount === 0) {
+			lines.push(
+				"- No layout files were resolved for the current routes. Consider adding a root `layout.tsx` if you want explicit shared application chrome.",
+			);
+		} else {
+			lines.push(
+				`- Layout inheritance is already in use across ${summary.layoutCount} unique layout file(s).`,
+			);
+		}
+		if (summary.routesWithLoading === 0) {
+			lines.push(
+				"- No route currently exposes `loading.tsx`, so loading-state conventions are still minimal.",
+			);
+		}
+		if (summary.routesWithErrorBoundary === 0) {
+			lines.push(
+				"- No route currently exposes an error boundary file, so runtime error handling is still implicit.",
+			);
+		}
+	}
 
 	writeFileSync(outputPath, `${lines.join("\n")}\n`, "utf8");
 
 	return outputPath;
+}
+
+function buildSummary(routes: RouteDefinition[]): InspectionReport["summary"] {
+	return {
+		routeCount: routes.length,
+		dynamicRouteCount: routes.filter((route) => route.dynamicParams?.length).length,
+		layoutCount: new Set(
+			routes
+				.map((route) => route.layout)
+				.filter((layout): layout is string => Boolean(layout)),
+		).size,
+		routesWithLoading: routes.filter((route) => route.hasLoading).length,
+		routesWithErrorBoundary: routes.filter((route) => route.hasErrorBoundary).length,
+		routesWithNotFound: routes.filter((route) => route.hasNotFound).length,
+	};
+}
+
+function buildConventions(config: AnastacioConfig): string[] {
+	return [
+		`File-based routing under \`${toProjectRelative(config.rootDir, config.paths.appDir)}\` by default.`,
+		"Layout inheritance uses the nearest `layout.tsx`.",
+		"Dynamic route segments are declared with bracket syntax such as `[id]` and emitted as `:id` in route metadata.",
+		"Route manifests and contextual artifacts are written to `.anastacio/`.",
+		`The runtime entry file is \`${toProjectRelative(config.rootDir, config.paths.entryFile)}\`.`,
+	];
 }
 
 function toProjectRelative(projectRoot: string, filePath: string): string {

--- a/src/inspector/inspectProject.ts
+++ b/src/inspector/inspectProject.ts
@@ -208,14 +208,16 @@ function writeProjectContext(
 function buildSummary(routes: RouteDefinition[]): InspectionReport["summary"] {
 	return {
 		routeCount: routes.length,
-		dynamicRouteCount: routes.filter((route) => route.dynamicParams?.length).length,
+		dynamicRouteCount: routes.filter((route) => route.dynamicParams?.length)
+			.length,
 		layoutCount: new Set(
 			routes
 				.map((route) => route.layout)
 				.filter((layout): layout is string => Boolean(layout)),
 		).size,
 		routesWithLoading: routes.filter((route) => route.hasLoading).length,
-		routesWithErrorBoundary: routes.filter((route) => route.hasErrorBoundary).length,
+		routesWithErrorBoundary: routes.filter((route) => route.hasErrorBoundary)
+			.length,
 		routesWithNotFound: routes.filter((route) => route.hasNotFound).length,
 	};
 }

--- a/src/plugins/AppRouter.ts
+++ b/src/plugins/AppRouter.ts
@@ -1,6 +1,6 @@
-import type { Plugin } from "esbuild";
 import { existsSync, mkdirSync } from "node:fs";
 import { relative } from "node:path";
+import type { Plugin } from "esbuild";
 import {
 	resolveRoutes,
 	writeGeneratedAppRouter,

--- a/src/plugins/DevEntry.ts
+++ b/src/plugins/DevEntry.ts
@@ -1,7 +1,7 @@
-import type { Plugin } from "esbuild";
+import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
-import { createHash } from "node:crypto";
+import type { Plugin } from "esbuild";
 import type { AnastacioConfig } from "../shared/contracts/index.js";
 
 export const DevPlugin = (config: AnastacioConfig): Plugin => ({

--- a/src/plugins/MinifyCss.ts
+++ b/src/plugins/MinifyCss.ts
@@ -1,6 +1,6 @@
-import type { Plugin } from "esbuild";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import type { Plugin } from "esbuild";
 import { Timer } from "../utils/Timer.js";
 
 export const MinifyCSSPlugin = (): Plugin => ({

--- a/src/plugins/MinifyImages.ts
+++ b/src/plugins/MinifyImages.ts
@@ -1,19 +1,19 @@
-import type { Plugin } from "esbuild";
 import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
 	readdirSync,
 	readFileSync,
-	writeFileSync,
-	copyFileSync,
 	rmSync,
-	mkdirSync,
-	existsSync,
 	statSync,
 	utimesSync,
+	writeFileSync,
 } from "node:fs";
-import { join, extname, basename } from "node:path";
+import { basename, extname, join } from "node:path";
+import type { Plugin } from "esbuild";
 import sharp from "sharp";
-import { Timer } from "../utils/Timer.js";
 import type { AnastacioConfig } from "../shared/contracts/index.js";
+import { Timer } from "../utils/Timer.js";
 
 export const MinifyImagesPlugin = (config: AnastacioConfig): Plugin => ({
 	name: "minify-images-plugin",

--- a/src/plugins/PostCSSPlugin.ts
+++ b/src/plugins/PostCSSPlugin.ts
@@ -1,9 +1,9 @@
+import { readFileSync } from "node:fs";
+import autoprefixer from "autoprefixer";
+import cssnano from "cssnano";
 import type { Plugin } from "esbuild";
 import postcss from "postcss";
 import tailwindcss from "tailwindcss";
-import autoprefixer from "autoprefixer";
-import cssnano from "cssnano";
-import { readFileSync } from "node:fs";
 
 export const PostCSSPlugin = (): Plugin => ({
 	name: "postcss-plugin",

--- a/src/plugins/ProdEntry.ts
+++ b/src/plugins/ProdEntry.ts
@@ -1,7 +1,7 @@
-import type { Plugin } from "esbuild";
+import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
-import { createHash } from "node:crypto";
+import type { Plugin } from "esbuild";
 import type { AnastacioConfig } from "../shared/contracts/index.js";
 
 export const ProdPlugin = (config: AnastacioConfig): Plugin => ({

--- a/src/router/generateAppRouter.ts
+++ b/src/router/generateAppRouter.ts
@@ -1,6 +1,9 @@
 import { existsSync, writeFileSync } from "node:fs";
 import { join, parse, relative, resolve } from "node:path";
-import type { AnastacioConfig, RouteDefinition } from "../shared/contracts/index.js";
+import type {
+	AnastacioConfig,
+	RouteDefinition,
+} from "../shared/contracts/index.js";
 
 const LOADING_FILE_NAMES = ["loading.tsx", "loading.jsx"];
 const NOT_FOUND_FILE_NAMES = [
@@ -61,7 +64,10 @@ export function createAppRouterSource(
 	}
 
 	const groupedLayoutRoutes = Array.from(layoutGroups.entries()).map(
-		([layoutComponent, routeLines]) => `      <Route element={<${layoutComponent} />}>
+		([
+			layoutComponent,
+			routeLines,
+		]) => `      <Route element={<${layoutComponent} />}>
 ${routeLines.join("\n")}
       </Route>`,
 	);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,3 +1,6 @@
-export { createAppRouterSource, writeGeneratedAppRouter } from "./generateAppRouter.js";
+export {
+	createAppRouterSource,
+	writeGeneratedAppRouter,
+} from "./generateAppRouter.js";
 export { resolveRoutes } from "./resolveRoutes.js";
 export { writeRoutesManifest } from "./writeRoutesManifest.js";

--- a/src/router/resolveRoutes.ts
+++ b/src/router/resolveRoutes.ts
@@ -78,7 +78,9 @@ function createRouteDefinition(
 	return {
 		path: toRoutePath(segments),
 		file: toProjectRelative(config.rootDir, pageFile),
-		...(layoutFile ? { layout: toProjectRelative(config.rootDir, layoutFile) } : {}),
+		...(layoutFile
+			? { layout: toProjectRelative(config.rootDir, layoutFile) }
+			: {}),
 		...(dynamicParams.length > 0 ? { dynamicParams } : {}),
 		hasLoading: hasKnownFile(currentDirectory, LOADING_FILE_NAMES),
 		hasErrorBoundary: hasKnownFile(currentDirectory, ERROR_FILE_NAMES),
@@ -137,7 +139,9 @@ function sortRoutes(left: RouteDefinition, right: RouteDefinition): number {
 		return 1;
 	}
 
-	return left.path.localeCompare(right.path) || left.file.localeCompare(right.file);
+	return (
+		left.path.localeCompare(right.path) || left.file.localeCompare(right.file)
+	);
 }
 
 function normalizePath(value: string): string {


### PR DESCRIPTION
## Summary
This follow-up PR brings the commits that landed on `feat/anastacio-v2-migration` after PR #2 was merged into `dev`.

### Includes
- runtime hardening and static asset serving cleanup
- stronger `doctor` diagnostics
- richer `inspect` output and project context
- CI + npm release workflow
- package prepared for the next publish line
- oxlint Linux binding fix for GitHub Actions

## Why
PR #2 was merged into `dev` before the later commits on the feature branch were included, so `dev` is currently missing the final v2 migration work.